### PR TITLE
Ensure the primary make file is included in newer:drushmake

### DIFF
--- a/tasks/drush.js
+++ b/tasks/drush.js
@@ -34,7 +34,7 @@ module.exports = function(grunt) {
   // source directory to catch make files included from the primary one.
   grunt.config('drushmake', {
     default: {
-      src: '<%= config.srcPaths.drupal %>/**/*.make',
+      src: ['<%= config.srcPaths.make %>', '<%= config.srcPaths.drupal %>/**/*.make'],
       dest: '<%= config.buildPaths.html %>'
     }
   });


### PR DESCRIPTION
This make file may not be located in the Drupal src directory.
