### PR TITLE
Avoid removing the build output directory before a new build finishes

### DIFF
--- a/example/Gruntconfig.json
+++ b/example/Gruntconfig.json
@@ -7,7 +7,8 @@
     "build": "build",
     "html": "build/html",
     "package": "build/packages",
-    "reports": "build/reports"
+    "reports": "build/reports",
+    "temp": "build/temp"
   },
   "siteUrls": {
     "default": "http://project.local"

--- a/tasks/clean.js
+++ b/tasks/clean.js
@@ -12,10 +12,13 @@ module.exports = function(grunt) {
   grunt.loadTasks(__dirname + '/../node_modules/grunt-contrib-clean/tasks');
   grunt.config('clean', {
     default: [
-      '<%= config.buildPaths.build %>'
+      '<%= config.buildPaths.html %>'
     ],
     sites: [
       '<%= config.buildPaths.html %>/sites/default'
+    ],
+    temp: [
+      '<%= config.buildPaths.temp %>'
     ]
   });
 

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -13,7 +13,17 @@ module.exports = function(grunt) {
         {
           expand: true,
           cwd: '<%= config.srcPaths.drupal %>/static',
-          src: ['*', '.*'],
+          src: ['**', '.**'],
+          dest: '<%= config.buildPaths.html %>'
+        }
+      ]
+    },
+    tempbuild: {
+      files: [
+        {
+          expand: true,
+          cwd: '<%= config.buildPaths.temp %>',
+          src: ['**', '.**'],
           dest: '<%= config.buildPaths.html %>'
         }
       ]

--- a/tasks/drush.js
+++ b/tasks/drush.js
@@ -21,12 +21,12 @@ module.exports = function(grunt) {
   grunt.config('drush', {
     make: {
       args: args,
-      dest: '<%= config.buildPaths.html %>'
+      dest: '<%= config.buildPaths.temp %>'
     }
   });
 
   grunt.registerTask('drushmake', 'Run "drush make" if the makefile is newer than the dest directory.', function() {
-    grunt.task.run('clean:default', 'mkdir:init', 'drush:make');
+    grunt.task.run('mkdir:init', 'drush:make', 'clean:default', 'copy:tempbuild', 'clean:temp');
   });
 
   // The "drushmake" task will run make only if the src file specified here is


### PR DESCRIPTION
Updating drushmake and copy tasks to build into a temp directory and then copy the output on success. This avoids removing the last build's output before the new build is successful.

Note: This changes the behavior of "clean:default" from removing the entire build directory to instead remove only the html output directory (usually, build/html).
