### PR TITLE
use grunt-contrib-compass for theme compilation

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -232,6 +232,12 @@ This is an example of the settings for theme tasks:
 **themes**: Defines each custom Drupal theme and enables features, like Sass
 processing by Compass.
 
+**themes.<theme>.compass**: Enable compass preprocessing. Either `true` to 
+enable with default compass options, or a configuration object to be passed 
+directly to 
+[grunt-contrib-compass](https://github.com/gruntjs/grunt-contrib-compass)
+for this theme.
+
 ### Validate Settings
 
 This is an example of the settings for the validate tasks:

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "grunt-composer": "0.2.0",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-copy": "~0.5.0",
+    "grunt-contrib-compass": "^1.0.1",
     "grunt-contrib-symlink": "~0.2.0",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-drush": "0.0.1",

--- a/tasks/theme.js
+++ b/tasks/theme.js
@@ -9,39 +9,57 @@ module.exports = function(grunt) {
    * Example:
    *
    * "themes": {
+   *   "viking": {
+   *     "path": "<%= config.srcPaths.drupal %>/themes/viking",
+   *     "compass": true
+   *   },
    *   "spartan": {
    *     "path": "<%= config.srcPaths.drupal %>/themes/spartan",
-   *     "compass": true
+   *     "compass": {
+   *       "environment": "development",
+   *       "sourcemap": true
+   *     }
    *   },
    *   "trojan": {
    *     "path": "<%= config.srcPaths.drupal %>/themes/trojan"
    *   }
    * }
    */
-  grunt.loadNpmTasks('grunt-shell');
 
-  var config = grunt.config.get('config');
+  grunt.loadNpmTasks('grunt-contrib-compass');
+
+  var config = grunt.config.get('config'),
+    util = require('util'),
+    steps = [];
+
   if (config.themes) {
-    var steps = []
     for (var key in config.themes) {
       if (config.themes.hasOwnProperty(key) && config.themes[key].compass) {
-        var path = config.themes[key].path;
-        grunt.config(['shell', 'compass-' + key], {
-          command: 'bundle exec "compass compile --time --app-dir=' + path + ' --config=' + path + '/config.rb"'
+        var theme = config.themes[key],
+          options = (theme.compass && typeof theme.compass === 'object') ? theme.compass : {};
+
+        grunt.config(['compass', key], {
+          options: util._extend({
+            basePath: theme.path,
+            config: theme.path + '/config.rb',
+            bundleExec: true
+          }, options)
         });
-        steps.push('shell:compass-' + key);
+
+        steps.push('compass:' + key);
 
         // Integrate compass compilation with sass.
         // Does not narrow down more specific than a sass/ directory because
         // that location is subject only to the theme's config.rb.
-        grunt.config(['watch', 'scss-' + key], {
+        grunt.config(['watch', key], {
           files: [
-            path + '/**/*.scss'
+            theme.path + '/**/*.scss'
           ],
-          tasks: ['shell:compass-' + key]
+          tasks: ['compass:' + key]
         });
       }
     }
+
     grunt.registerTask('compile-theme', steps);
 
     grunt.config('help.compile-theme', {


### PR DESCRIPTION
This is a backwards compatible switch to using grunt-contrib-compass to compile theme assets, instead of building the command in a shell task. Ideally the options object for grunt-contrib-compass could be defined directly in the Gruntconfig.json (and merged with the defaults), which would allow full control over the theme tasks from config. That may require some breaking changes to the config though, or some extra work to support the current config structure.
