### PR TITLE
Use loadNpmTasks to load plugin dependencies

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,8 +10,12 @@ module.exports = function(grunt) {
     config: config
   });
 
-  // Load all included tasks.
-  grunt.loadTasks(__dirname + '/tasks');
+  // Load all tasks from grunt-drupal-tasks. Ensure the tasks are loaded from
+  // the grunt-drupal-tasks directory, so plugin dependencies are found.
+  var pathOrig = process.cwd();
+  process.chdir(__dirname);
+  grunt.loadTasks('./tasks');
+  process.chdir(pathOrig);
 
   // Define the default task to fully build and configure the project.
   var tasksDefault = [

--- a/tasks/behat.js
+++ b/tasks/behat.js
@@ -14,7 +14,7 @@ module.exports = function(grunt) {
    *     }
    *   }
    */
-  grunt.loadTasks(__dirname + '/../node_modules/grunt-parallel-behat/tasks');
+  grunt.loadNpmTasks('grunt-parallel-behat');
   var config = grunt.config.get('config');
   var flags = grunt.option('flags') || '';
   if (config.buildPaths.html && config.siteUrls) {

--- a/tasks/bundler.js
+++ b/tasks/bundler.js
@@ -6,7 +6,7 @@ module.exports = function(grunt) {
    * If a Gemfile is defined in the repository root, add a grunt task to run
    * "bundle install".
    */
-  grunt.loadTasks(__dirname + '/../node_modules/grunt-shell/tasks');
+  grunt.loadNpmTasks('grunt-shell');
 
   if (grunt.file.exists('Gemfile')) {
     grunt.config(['shell', 'bundleInstall'], {

--- a/tasks/clean.js
+++ b/tasks/clean.js
@@ -9,7 +9,7 @@ module.exports = function(grunt) {
    * grunt clean:sites
    *   Removes sites/default in the build/html directory.
    */
-  grunt.loadTasks(__dirname + '/../node_modules/grunt-contrib-clean/tasks');
+  grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.config('clean', {
     default: [
       '<%= config.buildPaths.html %>'

--- a/tasks/composer.js
+++ b/tasks/composer.js
@@ -6,7 +6,7 @@ module.exports = function(grunt) {
    * Dynamically adds a Composer install task if a composer.json file
    * exists in the project directory.
    */
-  grunt.loadTasks(__dirname + '/../node_modules/grunt-composer/tasks');
+  grunt.loadNpmTasks('grunt-composer');
   var config = grunt.config.get('config');
   if (require('fs').existsSync('./composer.json')) {
     grunt.config(['composer', 'install'], {});

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -6,7 +6,7 @@ module.exports = function(grunt) {
    * grunt copy:static
    *   Copies all files from src/static to the build/html directory.
    */
-  grunt.loadTasks(__dirname + '/../node_modules/grunt-contrib-copy/tasks');
+  grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.config('copy', {
     static: {
       files: [

--- a/tasks/drush.js
+++ b/tasks/drush.js
@@ -6,8 +6,8 @@ module.exports = function(grunt) {
    * grunt drush:make
    *   Builds the Drush make file to the build/html directory.
    */
-  grunt.loadTasks(__dirname + '/../node_modules/grunt-drush/tasks');
-  grunt.loadTasks(__dirname + '/../node_modules/grunt-newer/tasks');
+  grunt.loadNpmTasks('grunt-drush');
+  grunt.loadNpmTasks('grunt-newer');
 
   // Allow extra arguments for drush to be supplied.
   var args = ['make', '<%= config.srcPaths.make %>'],

--- a/tasks/mkdir.js
+++ b/tasks/mkdir.js
@@ -9,7 +9,7 @@ module.exports = function(grunt) {
    * grunt mkdir:files
    *   Creates sites/default/files in the build/html directory.
    */
-  grunt.loadTasks(__dirname + '/../node_modules/grunt-mkdir/tasks');
+  grunt.loadNpmTasks('grunt-mkdir');
   grunt.config('mkdir', {
     init: {
       options: {

--- a/tasks/package.js
+++ b/tasks/package.js
@@ -6,7 +6,7 @@ module.exports = function(grunt) {
    * grunt package
    *   Builds a deployment package in the build/package directory.
    */
-  grunt.loadTasks(__dirname + '/../node_modules/grunt-contrib-compress/tasks');
+  grunt.loadNpmTasks('grunt-contrib-compress');
   var config = grunt.config.get('config'),
     srcFiles = (config.packages && config.packages.srcFiles && config.packages.srcFiles.length) ? config.packages.srcFiles : [],
     projFiles = (config.packages && config.packages.projFiles && config.packages.projFiles.length) ? config.packages.projFiles : [];

--- a/tasks/quality.js
+++ b/tasks/quality.js
@@ -13,9 +13,9 @@ module.exports = function(grunt) {
    *   Deeper inspection & analyze of codebase, not done on every build.
    *   Produces reports for Jenkins. May be a long-running task.
    */
-  grunt.loadTasks(__dirname + '/../node_modules/grunt-phplint/tasks');
-  grunt.loadTasks(__dirname + '/../node_modules/grunt-phpcs/tasks');
-  grunt.loadTasks(__dirname + '/../node_modules/grunt-phpmd/tasks');
+  grunt.loadNpmTasks('grunt-phplint');
+  grunt.loadNpmTasks('grunt-phpcs');
+  grunt.loadNpmTasks('grunt-phpmd');
 
   // Task set aliases are registered at the end of the file based on these values.
   var validate = [];

--- a/tasks/symlink.js
+++ b/tasks/symlink.js
@@ -20,7 +20,7 @@ module.exports = function(grunt) {
    *   Makes a symbolic link to src/themes from sites/all/themes/custom in the
    *   build/html directory.
    */
-  grunt.loadTasks(__dirname + '/../node_modules/grunt-contrib-symlink/tasks');
+  grunt.loadNpmTasks('grunt-contrib-symlink');
   grunt.config('symlink', {
     modules: {
       src: '<%= config.srcPaths.drupal %>/modules',

--- a/tasks/theme.js
+++ b/tasks/theme.js
@@ -18,7 +18,7 @@ module.exports = function(grunt) {
    *   }
    * }
    */
-  grunt.loadTasks(__dirname + '/../node_modules/grunt-shell/tasks');
+  grunt.loadNpmTasks('grunt-shell');
 
   var config = grunt.config.get('config');
   if (config.themes) {

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -7,7 +7,7 @@ module.exports = function(grunt) {
    * the Drupal docroot changes (except for files in sites/.../files) or when
    * a file in the testing features directory changes.
    */
-  grunt.loadTasks(__dirname + '/../node_modules/grunt-contrib-watch/tasks');
+  grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.config(['watch', 'behat'], {
     files: [
       '<%= config.srcPaths.drupal %>/**/*',

--- a/tasks/zzz_help.js
+++ b/tasks/zzz_help.js
@@ -7,7 +7,7 @@ module.exports = function(grunt) {
    *   Provides an overview of intended and useful grunt tasks.
    */
 
-  grunt.loadTasks(__dirname + '/../node_modules/grunt-available-tasks/tasks');
+  grunt.loadNpmTasks('grunt-available-tasks');
 
   grunt.config('help.default', {
     group: 'Build Process'


### PR DESCRIPTION
This implements an alternative workaround to support loading Grunt plugins installed in grunt-drupal-tasks/node_modules rather than the original working dir. This approach allows loading plugins with loadNpmTasks() instead of the current hack with loadTasks().
