### PR TITLE
Set Behat CLI options in Gruntconfig.json and at runtime

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -190,12 +190,21 @@ This is an example of the settings for Behat tasks:
   "siteUrls": {
     "default": "http://project.local",
     "subsite": "http://subsite.project.local"
+  },
+  "behat": {
+    "flags": "--tags '~@javascript'"
   }
 }
 ```
 
 **siteUrls**: A map of Drupal subsite names to the URLs by which each can be
 accessed for testing by Behat.
+
+**behat.flags**: A string with any command-line arguments and options that
+should be used while invoking Behat. These flags can be overridden by using the
+`--behat-flags` option when running `grunt`. Common use cases are to include or
+exclude tests according to tags or to use an alternative profile defined in
+`behat.yml`.
 
 ### Drush Settings
 

--- a/example/Gruntconfig.json
+++ b/example/Gruntconfig.json
@@ -29,5 +29,8 @@
       "args": []
     }
   },
-  "compassConfig": {}
+  "compassConfig": {},
+  "behat": {
+    "flags": "--tags '~@javascript'"
+  }
 }

--- a/tasks/behat.js
+++ b/tasks/behat.js
@@ -16,7 +16,13 @@ module.exports = function(grunt) {
    */
   grunt.loadNpmTasks('grunt-parallel-behat');
   var config = grunt.config.get('config');
-  var flags = grunt.option('flags') || '';
+  var flags = '';
+  if (grunt.option('behat_flags')) {
+    flags = grunt.option('behat_flags');
+  }
+  else if (config.behat && config.behat.flags) {
+    flags = config.behat.flags;
+  }
   if (config.buildPaths.html && config.siteUrls) {
     for (var key in config.siteUrls) {
       if (config.siteUrls.hasOwnProperty(key)) {


### PR DESCRIPTION
Adding Gruntconfig.json option for behat.flags that defines default command-line options to pass to Behat. Adding default in the example Gruntconfig.json to exclude tests tagged with 'javascript'.
