### PR TITLE
Removing the timestamp from the filename created by the package operation

### DIFF
--- a/tasks/package.js
+++ b/tasks/package.js
@@ -14,7 +14,7 @@ module.exports = function(grunt) {
     package: {
       options: {
         archive: function () {
-          return grunt.config.get('config.buildPaths.package') + '/package-' + new Date().toISOString() + '.tgz';
+          return grunt.config.get('config.buildPaths.package') + '/package.tgz';
         },
         mode: 'tgz'
       },


### PR DESCRIPTION
Addresses issue #44.
