### PR TITLE
Restore Behat task's settings injection

### DIFF
--- a/tasks/behat.js
+++ b/tasks/behat.js
@@ -39,7 +39,7 @@ module.exports = function(grunt) {
           flags: flags,
           debug: true,
           env: {
-            "BEHAT_PARAMS": "extensions[Drupal\\DrupalExtension\\Extension][drupal][drupal_root]=" + config.buildPaths.html,
+            "BEHAT_PARAMS": "{\"extensions\": {\"Drupal\\\\DrupalExtension\": {\"drupal\": {\"drupal_root\": \"" + config.buildPaths.html + "\"}}}}",
             "MINK_EXTENSION_PARAMS": "base_url=" + config.siteUrls[key]
           }
         });


### PR DESCRIPTION
This restores the Behat task's code to override the Drupal root path and Drupal site base URL given in behat.yml based on settings in Gruntconfig.json.

The goals are to consolidate site settings in Gruntconfig.json, to support sites with multiple URLs, and allow environment-specific modifications (per #32 and #41).

Other changes include documentation clean up, and updating the BEHAT_PARAMS syntax for Behat version 3, which changed to use json format.
