### PR TITLE
#42 Add ESLint support with grunt-eslint [WIP]

### DIFF
--- a/example/.eslintrc
+++ b/example/.eslintrc
@@ -1,0 +1,32 @@
+{
+  "env": {
+    "browser": true
+  },
+  "globals": {
+    "Drupal": true,
+    "drupalSettings": true,
+    "domready": true,
+    "jQuery": true,
+    "_": true,
+    "matchMedia": true,
+    "Backbone": true,
+    "Modernizr": true,
+    "CKEDITOR": true
+  },
+  "rules": {
+    "eqeqeq": [2, "smart"],
+    "guard-for-in": 2,
+    "no-undef": 2,
+    "no-unused-vars": 0,
+    "strict": 2,
+    "new-cap": 0,
+    "quotes": 0,
+    "camelcase": 0,
+    "no-underscore-dangle": 0,
+    "no-new": 0,
+    "no-alert": 0,
+    "no-use-before-define": 0,
+    "consistent-return": 0,
+    "no-constant-condition": 0
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "grunt-contrib-symlink": "~0.2.0",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-drush": "~0.0.3",
+    "grunt-eslint": "^2.0.0",
     "grunt-mkdir": "0.1.1",
     "grunt-newer": "~0.7.0",
     "grunt-shell": "~0.7.0",

--- a/tasks/quality.js
+++ b/tasks/quality.js
@@ -16,6 +16,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-phplint');
   grunt.loadNpmTasks('grunt-phpcs');
   grunt.loadNpmTasks('grunt-phpmd');
+  grunt.loadNpmTasks('grunt-eslint');
 
   // Task set aliases are registered at the end of the file based on these values.
   var validate = [];
@@ -103,6 +104,11 @@ module.exports = function(grunt) {
     });
     analyze.push('phpmd:custom');
   }
+
+  grunt.config('eslint', grunt.config.get('eslint') || {
+    target: ['<%= config.srcPaths.drupal %>/**/*.js']
+  });
+  validate.push('eslint');
 
   grunt.registerTask('validate', validate);
   grunt.registerTask('analyze', analyze);


### PR DESCRIPTION
In reference to #42 (and https://github.com/phase2/grunt-drupal-tasks/issues/42#issuecomment-64136831), this is what ESLint support might look like. The included .eslintrc is from https://www.drupal.org/node/1955232.

Note that these example settings may not be the "best" for validating JS in the context of what grunt-drupal-tasks is trying to provide. They are agreed upon for D8, but whether or not they should be the suggested defaults for all Drupal projects is probably up for debate.