### PR TITLE
Add support for configurable grunt-parallel-behat options

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -187,18 +187,24 @@ This is an example of the settings for Behat tasks:
 
 ```
 {
-  "siteUrls": {
-    "default": "http://project.local",
-    "subsite": "http://subsite.project.local"
-  },
-  "behat": {
-    "flags": "--tags '~@javascript'"
-  }
+   "siteUrls": {
+      "default": "http://dev-site.local",
+      "subsite": "http://sub.dev-site.local"
+   },
+   "behat": {
+      "subsite": {
+         "src": "./features/subsite/*.feature",         
+         "debug": false
+      }
+   }
 }
 ```
 
 **siteUrls**: A map of Drupal subsite names to the URLs by which each can be
 accessed for testing by Behat.
+
+**behat.\<siteurl\>**: A map of Drupal subsite names to a configuration object, which will extend the defaults passed to
+[grunt-parallel-behat](https://github.com/linusnorton/grunt-parallel-behat)
 
 **behat.flags**: A string with any command-line arguments and options that
 should be used while invoking Behat. These flags can be overridden by using the
@@ -241,7 +247,7 @@ This is an example of the settings for theme tasks:
 **themes**: Defines each custom Drupal theme and enables features, like Sass
 processing by Compass.
 
-**themes.<theme>.compass**: Enable compass preprocessing. Either `true` to 
+**themes.\<theme\>.compass**: Enable compass preprocessing. Either `true` to 
 enable with default compass options, or a configuration object to be passed 
 directly to 
 [grunt-contrib-compass](https://github.com/gruntjs/grunt-contrib-compass)

--- a/tasks/behat.js
+++ b/tasks/behat.js
@@ -9,35 +9,55 @@ module.exports = function(grunt) {
    * Example:
    *   "config": {
    *     "docroot": "/var/www/vhosts/dev-site.local",
-   *     "site_urls": {
-   *       default: http://dev-site.local"
+   *     "siteUrls": {
+   *       "default": "http://dev-site.local",
+   *       "subsite": "http://sub.dev-site.local"
+   *     },
+   *     "behat": {
+   *       "subsite": {
+   *          "src": "./features/subsite/*.feature",
+   *          "debug": false
+   *       }
    *     }
    *   }
    */
   grunt.loadNpmTasks('grunt-parallel-behat');
   var config = grunt.config.get('config');
   var flags = '';
-  if (grunt.option('behat_flags')) {
-    flags = grunt.option('behat_flags');
-  }
-  else if (config.behat && config.behat.flags) {
-    flags = config.behat.flags;
-  }
+  var util = require('util');
+
   if (config.buildPaths.html && config.siteUrls) {
     for (var key in config.siteUrls) {
       if (config.siteUrls.hasOwnProperty(key)) {
-        grunt.config(['behat', 'site-' + key], {
-          src: './features/*.feature',
-          config: './behat.yml',
-          maxProcesses: 5,
-          bin: './bin/behat',
-          flags: flags,
-          debug: true,
-          env: {
-            //"BEHAT_PARAMS": "extensions[Drupal\\DrupalExtension\\Extension][drupal][drupal_root]=./" + config.buildPaths.html,
-            //"MINK_EXTENSION_PARAMS": "base_url=" + config.siteUrls[key]
+        var options = {};
+
+        // Check for per-site behat options.
+        if (config.behat && config.behat[key]) {
+          var siteOptions = config.behat[key];
+          options = (typeof siteOptions === 'object') ? siteOptions : options;
+        }
+
+        // Support for global behat flags config.
+        if (!options.flags) {
+          if (config.behat.flags) {
+            options.flags = config.behat.flags;
           }
-        });
+        }
+        
+        // Override with flags at runtime.
+        if (grunt.option('behat_flags')) {
+          options.flags = grunt.option('behat_flags');
+        }
+        
+        grunt.config(['behat', 'site-' + key],
+          util._extend({
+            src: './features/*.feature',
+            config: './behat.yml',
+            maxProcesses: 5,
+            bin: './bin/behat',
+            debug: true
+          }, options)
+        );
       }
     }
 


### PR DESCRIPTION
In the process of debugging the issue described [here](https://github.com/linusnorton/grunt-parallel-behat/pull/9), I implemented this change to the Behat configuration and option passing to grunt-parallel-behat. 

This works the same as the config for grunt-contrib-compass, and allows the defaults in grunt-drupal-tasks to be extended on a per-URL basis based on the keys defined in the `siteUrls` config. I left the `siteUrls` as a separate configuration option, since it may be useful in other contexts than Behat in the future. An example of how this would be useful is shown in the README.

Note that this impacts #60, and perhaps how you want to handle the `flags` option (though I kept support for this as-is, including the runtime support).
