### PR TITLE
Behat configuration throws an error on load if config.behat is not defined

### DIFF
--- a/tasks/behat.js
+++ b/tasks/behat.js
@@ -41,7 +41,7 @@ module.exports = function(grunt) {
         }
 
         // Support for global behat flags config.
-        if (!options.flags && config.behat.flags) {
+        if (!options.flags && config.behat && config.behat.flags) {
           options.flags = config.behat.flags;
         }
 


### PR DESCRIPTION
behat.js cannot currently load if Gruntconfig.json does not have a behat key configured. I've added an extra check to fix the immediate error, but we may want to follow the pattern in PHPCS and PHPMD, and simply not configure a behat task if that key does not exist.
