### PR TITLE
Renamed bundleInstall to bundle-install for task name consistency.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,8 +34,8 @@ module.exports = function(grunt) {
   if (grunt.config.get(['composer', 'install'])) {
     tasksDefault.unshift('composer:install');
   }
-  if (grunt.task.exists('bundleInstall')) {
-    tasksDefault.unshift('bundleInstall');
+  if (grunt.task.exists('bundle-install')) {
+    tasksDefault.unshift('bundle-install');
   }
   if (grunt.task.exists('compile-theme')) {
     tasksDefault.push('compile-theme');

--- a/tasks/bundler.js
+++ b/tasks/bundler.js
@@ -9,12 +9,15 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-shell');
 
   if (grunt.file.exists('Gemfile')) {
-    grunt.config(['shell', 'bundleInstall'], {
+    grunt.config(['shell', 'bundle-install'], {
       command: "bundle install --binstubs=gems/bin"
     });
-    grunt.registerTask('bundleInstall', ['shell:bundleInstall']);  
 
-    grunt.config('help.bundleInstall', {
+    // camelCase is deprecated.
+    grunt.registerTask('bundleInstall', ['shell:bundle-install']);  
+    grunt.registerTask('bundle-install', ['shell:bundle-install']);  
+
+    grunt.config('help.bundle-install', {
       group: 'Dependency Management',
       description: 'Run `bundle install`, dropping symlinks to all binaries in `gems/bin`.'
     });


### PR DESCRIPTION
We've pretty much standardized on hyphenates, this was bothering me. Would be good to add a bullet to the upgade path note in the #72's changelog, but I wanted to keep this merge simple.
