### PR TITLE
Run grunt tasks with the --timer flag for testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ install:
   - npm install -g mocha
 script:
   - export PATH=$PATH:`pwd`/bin
-  - grunt
-  - grunt drush:liteinstall
+  - grunt --timer
+  - grunt drush:liteinstall --timer
   - grunt drush:runserver &
   - until netstat -an 2>/dev/null | grep '8080.*LISTEN'; do sleep 0.2; done
-  - grunt behat
+  - grunt behat --timer
   - mocha node_modules/grunt-drupal-tasks/test


### PR DESCRIPTION
It would be useful inspect the timing information on travis grunt runs for occasional spot checks.
