### PR TITLE
Add Dependency Status badge via david-dm.org.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Code Status (master branch):
 <a href="https://travis-ci.org/phase2/grunt-drupal-tasks"><img src="https://travis-ci.org/phase2/grunt-drupal-tasks.svg?branch=master"></a>
+[![Dependency Status](https://david-dm.org/phase2/grunt-drupal-tasks.svg)](https://david-dm.org/phase2/grunt-drupal-tasks)
 
 ## Requirements
 


### PR DESCRIPTION
Fixes #37 

Looks like we're a bit behind on a few things. Badge in README links to https://david-dm.org/phase2/grunt-drupal-tasks
