### PR TITLE
Change grunt.task.rename to grunt.task.renameTask.

### DIFF
--- a/EXTEND.md
+++ b/EXTEND.md
@@ -18,7 +18,7 @@ typing `grunt` into the command-line.)
    example.
 
 ```js
-grunt.task.rename('default', 'default-original');
+grunt.task.renameTask('default', 'default-original');
 grunt.registerTask('default', ['shell:custom', 'default-original']);
 ```
 


### PR DESCRIPTION
According to the current [documentation](http://gruntjs.com/api/grunt.task#grunt.task.renametask), this is the proper method name.
