### PR TITLE
Do not use null for dest

### DIFF
--- a/tasks/drush.js
+++ b/tasks/drush.js
@@ -25,12 +25,12 @@ module.exports = function(grunt) {
     },
     liteinstall: {
       args: ['site-install', '-y', 'standard', '--db-url=sqlite://drupal:drupal@drupal.sqlite'],
-      dest: null,
+      dest: '',
       cwd: '<%= config.buildPaths.html %>'
     },
     runserver: {
       args: ['runserver', '8080'],
-      dest: null,
+      dest: '',
       cwd: '<%= config.buildPaths.html %>'
     }
   });


### PR DESCRIPTION
Using a null value for dest causes the drush command to look like "drush runserver 8080 null". The dest (or src) property is required since grunt-drush uses `this.files` to parse target configuration in the multitask (https://github.com/nickpack/grunt-drush/blob/master/tasks/drush.js#L25). Also, dest is always added to the arguments due to a [bug](https://github.com/nickpack/grunt-drush/pull/8) in the way grunt-drush checks whether or not it is defined. Using an empty string, dest is still added to the arguments, but doesn't have the potential to cause any unintended side-effects.

Related issues:
- https://github.com/nickpack/grunt-drush/issues/7
- https://github.com/nickpack/grunt-drush/pull/8
