### PR TITLE
Switching back to the current upstream version of Grunt Parallel Behat

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "grunt-mkdir": "~0.1.1",
     "grunt-newer": "~0.8.0",
     "grunt-shell": "^1.1.1",
-    "grunt-parallel-behat": "git+https://github.com/arithmetric/grunt-parallel-behat.git",
+    "grunt-parallel-behat": "~0.3.6",
     "grunt-phplint": "~0.0.5",
     "grunt-phpcs": "git+https://github.com/grayside/grunt-phpcs.git#0.3.0",
     "grunt-contrib-compress": "~0.12.0",

--- a/tasks/behat.js
+++ b/tasks/behat.js
@@ -51,16 +51,18 @@ module.exports = function(grunt) {
         }
 
         grunt.config(['behat', 'site-' + key],
-          _.extend({
-            src: './features/*.feature',
-            config: './behat.yml',
-            maxProcesses: 5,
-            bin: './bin/behat',
-            debug: true,
-            env: {
-              "BEHAT_PARAMS": "{\"extensions\": {\"Drupal\\\\DrupalExtension\": {\"drupal\": {\"drupal_root\": \"./" + config.buildPaths.html + "\"}}, \"Behat\\\\MinkExtension\": {\"base_url\": \"" + config.siteUrls[key] + "\"}}}"
-            }
-          }, options)
+          {
+            src: options.src || './features/**/*.feature',
+            options: _.extend({
+              config: './behat.yml',
+              maxProcesses: 5,
+              bin: './bin/behat',
+              debug: true,
+              env: {
+                "BEHAT_PARAMS": "{\"extensions\": {\"Drupal\\\\DrupalExtension\": {\"drupal\": {\"drupal_root\": \"./" + config.buildPaths.html + "\"}}, \"Behat\\\\MinkExtension\": {\"base_url\": \"" + config.siteUrls[key] + "\"}}}"
+              }
+            }, options)
+          }
         );
       }
     }


### PR DESCRIPTION
Switching back to the current upstream version of Grunt Parallel Behat from my fork. Updating Behat options to conform with updated version.

Resolves #66.
