### PR TITLE
Replacing the deprecated grunt.util._ external library

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "grunt-phpmd": "~0.1.0",
     "time-grunt": "^0.4.0",
     "grunt-parallel": "^0.3.1",
-    "grunt-available-tasks": "~0.5.0"
+    "grunt-available-tasks": "~0.5.0",
+    "lodash": "^2.4.1"
   },
   "keywords": [
     "build",

--- a/tasks/behat.js
+++ b/tasks/behat.js
@@ -27,7 +27,7 @@ module.exports = function(grunt) {
 
   var config = grunt.config.get('config'),
     flags = '',
-    util = require('util');
+    _ = require('lodash');
 
   if (config.buildPaths.html && config.siteUrls) {
     for (var key in config.siteUrls) {
@@ -51,7 +51,7 @@ module.exports = function(grunt) {
         }
 
         grunt.config(['behat', 'site-' + key],
-          util._extend({
+          _.extend({
             src: './features/*.feature',
             config: './behat.yml',
             maxProcesses: 5,

--- a/tasks/theme.js
+++ b/tasks/theme.js
@@ -29,7 +29,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-compass');
 
   var config = grunt.config.get('config'),
-    util = require('util'),
+    _ = require('lodash'),
     steps = [],
     parallelTasks = [];
 
@@ -40,7 +40,7 @@ module.exports = function(grunt) {
           options = (theme.compass && typeof theme.compass === 'object') ? theme.compass : {};
 
         grunt.config(['compass', key], {
-          options: util._extend({
+          options: _.extend({
             basePath: theme.path,
             config: theme.path + '/config.rb',
             bundleExec: true


### PR DESCRIPTION
Replacing the use of the deprecated grunt.util._ external library with lodash.
