### PR TITLE
Only load plugins when they are needed.

### DIFF
--- a/tasks/bundler.js
+++ b/tasks/bundler.js
@@ -6,14 +6,17 @@ module.exports = function(grunt) {
    * If a Gemfile is defined in the repository root, add a grunt task to run
    * "bundle install".
    */
-  grunt.loadNpmTasks('grunt-shell');
 
   if (grunt.file.exists('Gemfile')) {
-    grunt.config(['shell', 'bundle-install'], {
-      command: "bundle install --binstubs=gems/bin"
+    grunt.registerTask('bundle-install', 'Run `bundle install`, dropping symlinks to all binaries in `gems/bin`.', function() {
+      grunt.loadNpmTasks('grunt-shell');
+      grunt.config(['shell', 'bundle-install'], {
+        command: "bundle install --binstubs=gems/bin"
+      });
     });
-    grunt.registerTask('bundleInstall', ['shell:bundle-install']);
-    grunt.registerTask('bundle-install', ['shell:bundle-install']);
+
+    // camelCase is deprecated.
+    grunt.registerTask('bundleInstall', ['shell:bundle-install']);  
 
     grunt.config('help.bundle-install', {
       group: 'Dependency Management',

--- a/tasks/package.js
+++ b/tasks/package.js
@@ -6,10 +6,9 @@ module.exports = function(grunt) {
    * grunt package
    *   Builds a deployment package in the build/package directory.
    */
-  grunt.loadNpmTasks('grunt-contrib-compress');
   var config = grunt.config.get('config'),
-    srcFiles = (config.packages && config.packages.srcFiles && config.packages.srcFiles.length) ? config.packages.srcFiles : [],
-    projFiles = (config.packages && config.packages.projFiles && config.packages.projFiles.length) ? config.packages.projFiles : [];
+  srcFiles = (config.packages && config.packages.srcFiles && config.packages.srcFiles.length) ? config.packages.srcFiles : [],
+  projFiles = (config.packages && config.packages.projFiles && config.packages.projFiles.length) ? config.packages.projFiles : [];
   grunt.config('compress', {
     package: {
       options: {
@@ -39,6 +38,7 @@ module.exports = function(grunt) {
   });
 
   grunt.registerMultiTask('package', 'Package the operational codebase for deployment.', function() {
+    grunt.loadNpmTasks('grunt-contrib-compress');
     grunt.task.run(this.data);
   });
 

--- a/tasks/theme.js
+++ b/tasks/theme.js
@@ -26,14 +26,13 @@ module.exports = function(grunt) {
    * }
    */
 
-  grunt.loadNpmTasks('grunt-contrib-compass');
-
   var config = grunt.config.get('config'),
     _ = require('lodash'),
     steps = [],
     parallelTasks = [];
 
   if (config.themes) {
+    grunt.loadNpmTasks('grunt-contrib-compass');
     for (var key in config.themes) {
       if (config.themes.hasOwnProperty(key) && config.themes[key].compass) {
         var theme = config.themes[key],


### PR DESCRIPTION
As it is, plugin loading represents only 3-6ms, however this is still a best practice and hopefully will remind us in the future to load grunt plugins only when we're sure we'll need them.