### PR TITLE
Add SecurityAdvisories check to promote best practices

### DIFF
--- a/example/composer.json
+++ b/example/composer.json
@@ -9,5 +9,8 @@
         "drush/drush": "dev-master",
         "phpmd/phpmd": "~2.1",
         "drupal/coder": "7.2.3"
+    },
+    "require": {
+        "roave/security-advisories": "dev-master"
     }
 }


### PR DESCRIPTION
Anthony Ferrara suggested https://github.com/Roave/SecurityAdvisories should be added to all application composer.json files, and it makes a lot of sense to me. This project processes a security advisory database and produces a composer.json file that specifies package conflicts with insecure packages. As a result it will break composer update and composer require operations that include the insecure packages.

This doesn't really get us much for the tools we are proposing be used, as they are unlikely to have a problematic security issue, but since we are suggesting our composer.json file be a starting place, it seems like a really good practice to recommend.