### PR TITLE
Allow defaulting help descriptions in project Gruntconfig.json

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -316,3 +316,23 @@ this format, see: http://gruntjs.com/configuring-tasks#files
 **packages.projFiles**: An array of files or file patterns to include or exclude
 from the project directory when building a package. The above includes README
 files and files under bin/ in the project's package.
+
+### Help Settings
+
+If you add custom tasks to your project and want them exposed as part of the
+`help` task, you may add the following configuration to your `Gruntconfig.json`
+on a per task basis:
+
+```
+{
+  "help": {
+    "task-name": {
+      "group": "Include Task in this Named Group",
+      "description": "Optional description that overrides the default description you would see in `grunt -h`"
+    }
+  }
+}
+```
+
+If you want to include your task in one of the existing groupings, copy the text
+exactly as seen in the output of the `grunt help` task.

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -6,9 +6,9 @@ module.exports = function(grunt) {
   });
 
   // Allow Gruntconfig.json to set default descriptions.
+  // tasks/zzz_help.js checks the root 'help' config namespace.
   if (config.help) {
     grunt.config('help', config.help);
-    grunt.config('config.help', '');
   }
 
   // Wrap Grunt's loadNpmTasks() function to change the current directory to

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -5,6 +5,12 @@ module.exports = function(grunt) {
     config: config
   });
 
+  // Allow Gruntconfig.json to set default descriptions.
+  if (config.help) {
+    grunt.config('help', config.help);
+    grunt.config('config.help', '');
+  }
+
   // Wrap Grunt's loadNpmTasks() function to change the current directory to
   // grunt-drupal-tasks, so that module dependencies of it are found.
   grunt._loadNpmTasks = grunt.loadNpmTasks;


### PR DESCRIPTION
Help task requires configuration be loaded after bootstrap.js and before zzz_help.js is processed. This change allows projects to introduce custom task descriptions in Gruntfile.json so bootstrap.js picks it up.