### PR TITLE
Update bundler task aliases to wrap new shell target.

### DIFF
--- a/tasks/bundler.js
+++ b/tasks/bundler.js
@@ -12,8 +12,8 @@ module.exports = function(grunt) {
     grunt.config(['shell', 'bundle-install'], {
       command: "bundle install --binstubs=gems/bin"
     });
-    grunt.registerTask('bundleInstall', ['shell:bundleInstall']);
-    grunt.registerTask('bundle-install', ['shell:bundleInstall']);
+    grunt.registerTask('bundleInstall', ['shell:bundle-install']);
+    grunt.registerTask('bundle-install', ['shell:bundle-install']);
 
     grunt.config('help.bundle-install', {
       group: 'Dependency Management',


### PR DESCRIPTION
Bundler support is broken.