### PR TITLE
Allow Gruntconfig to specify phpcs failures throw error.

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -292,6 +292,9 @@ installs the Drupal Coder's standard, the path of which is shown above.
 **phpcs.dir**: An array of globbing pattern where phpcs should search for files.
 This can be used to replace the defaults supplied by grunt-drupal-tasks.
 
+**phpcs.ignoreExitCode**: Set to `false` if you want validate to fail on PHPCS
+issues.
+
 > If there is no `phpcs` key in the configuration, the system will assume you
 are not using PHPCS and will suppress it from the system.
 

--- a/tasks/quality.js
+++ b/tasks/quality.js
@@ -48,6 +48,9 @@ module.exports = function(grunt) {
     var phpStandard = grunt.config('config.phpcs.standard')
       || 'vendor/drupal/coder/coder_sniffer/Drupal';
 
+    var ignoreError = grunt.config('config.phpcs.ignoreExitCode');
+    ignoreError = ignoreError === undefined ? true : ignoreError;
+
     grunt.config('phpcs', {
       analyze: {
         dir: phpcs
@@ -79,7 +82,7 @@ module.exports = function(grunt) {
         bin: '<%= config.phpcs.path %>',
         standard: phpStandard,
         extensions: 'php,install,module,inc,profile',
-        ignoreExitCode: true,
+        ignoreExitCode: ignoreError,
         report: 'checkstyle',
         reportFile: '<%= config.buildPaths.reports %>/phpcs.xml'
       }


### PR DESCRIPTION
Simple override to specify that PHPCS failures should fail the build. Useful for strict projects. Waiting on Travis for actual testing.