### PR TITLE
Produce a tarball with .htaccess and other dotfiles. Fixes #113.

### DIFF
--- a/tasks/package.js
+++ b/tasks/package.js
@@ -21,8 +21,9 @@ module.exports = function(grunt) {
       files: [
         {
           expand: true,
+          dot: true,
           cwd: '<%= config.buildPaths.html %>',
-          src: ['**'].concat(srcFiles),
+          src: ['**', '!**/.gitkeep'].concat(srcFiles),
           dest: 'docroot/'
         },
         {


### PR DESCRIPTION
This configuration will default to including all dotfiles except the .gitkeep files that are present by default in the example project.