### PR TITLE
Dynamic Concurrency [BC Break]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## NEXT
+
+- Dynamically compute Drush Make concurrency based on system capability with a
+  new concurrency detection service.
+
+### Upgrade Notes
+
+- Remove --concurrency flag from your Gruntconfig. It will no logner be respected.
+
 ## v0.5.2 [2015/01/24]
 
 - Adding configuration for the Drush executable path, whether to trigger a fail

--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ to view documentation tailored for your project.
 
 To build your Drupal site, run `grunt`.
 
+### Special Flags
+
+These flags are not yet documented as part of the `grunt help` command.
+
+* `--quiet`: Suppress desktop notifications.
+* `--timer`: Output execution time profile at the end of the task run.
+* `--concurrency`: Override the dynamic concurrency by Drush Make.
+
+### Environment Options
+
+These environment variables will override other options.
+* `GRUNT_DRUPAL_QUIET`: If evaluated truthy, will suppress all desktop notifications.
+
 ## Setting Up and Extending
 
 For information on setting up your project with these tools, see

--- a/example/Gruntconfig.json
+++ b/example/Gruntconfig.json
@@ -24,10 +24,7 @@
     "path": "bin/phpmd"
   },
   "drush": {
-    "cmd": "bin/drush",
-    "make": {
-      "args": ["--concurrency=16"]
-    }
+    "cmd": "bin/drush"
   },
   "behat": {
     "flags": "--tags ~@wip"

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,3 @@
+module.exports = {
+  concurrency: Math.max((require('os').cpus().length || 1) * 2, 2)
+};

--- a/tasks/drush.js
+++ b/tasks/drush.js
@@ -32,7 +32,7 @@ module.exports = function(grunt) {
 
   grunt.config('drush', {
     make: {
-      args: args,
+      args: make_args,
       options: _.extend({}, cmd)
     },
     liteinstall: {

--- a/tasks/drush.js
+++ b/tasks/drush.js
@@ -13,18 +13,23 @@ module.exports = function(grunt) {
   var cmd = grunt.config('config.drush.cmd') || process.cwd() + '/bin/drush';
 
   // Allow extra arguments for drush to be supplied.
-  var args = ['make', '<%= config.srcPaths.make %>', '<%= config.buildPaths.temp %>'],
-    extra_args = grunt.config.get('config.drush.make.args');
+  var make_args = ['make', '<%= config.srcPaths.make %>', '<%= config.buildPaths.temp %>'];
+  var extra_args = grunt.config.get('config.drush.make.args');
+
   if (extra_args && extra_args.length) {
-    extra_args.unshift(args[0]);
-    extra_args.push(args[1]);
-    extra_args.push(args[2]);
-    args = extra_args;
+    extra_args.unshift(make_args[0]);
+    extra_args.push(make_args[1]);
+    extra_args.push(make_args[2]);
+    make_args = extra_args;
   }
+
+  var limit = grunt.option('concurrency') || require('../lib/util').concurrency;
+  make_args.push('--concurrency=' + limit);
+  grunt.verbose.writeln('Configured for concurrency=' + limit);
 
   grunt.config('drush', {
     make: {
-      args: args,
+      args: make_args,
       options: {
         cmd: cmd
       }

--- a/test/build.js
+++ b/test/build.js
@@ -71,3 +71,10 @@ describe('grunt', function() {
 
   });
 });
+
+describe('Utility Functions', function() {
+  it('should have "concurrency" to recommend a safe limit greater than 2', function() {
+    var limit = require('../lib/util').concurrency;
+    assert(limit >= 2, 'concurrency limit not >= 2');
+  });
+});

--- a/test/test_assets/Gruntconfig.json
+++ b/test/test_assets/Gruntconfig.json
@@ -24,10 +24,7 @@
     "path": "bin/phpmd"
   },
   "drush": {
-    "cmd": "bin/drush",
-    "make": {
-      "args": ["--concurrency=16"]
-    }
+    "cmd": "bin/drush"
   },
   "behat": {
     "flags": "--tags ~@wip"


### PR DESCRIPTION
This change switches from Gruntconfig.json-based Drush make concurrency to something dynamic. It leverages the safe concurrency algorithm from the grunt-concurrent plugin and injects that into the assembly of the make parameters.

In case someone doesn't like the default, it also allows manually specifying `--concurrency=#` in the command-line invocation to override. Along the way I went ahead and added flag documentation to the README.

**BC Break: I couldn't find a graceful way to allow the Gruntconfig to retain override capability over this parameter, but given the sensitivity of this functionality across environments it struck me as probably not as useful as having the CLI option anyway.**

Couldn't easily run the new test, so letting Travis report on it.

Fixes #103 