### PR TITLE
Changing bundle install default path options

### DIFF
--- a/tasks/bundler.js
+++ b/tasks/bundler.js
@@ -10,7 +10,7 @@ module.exports = function(grunt) {
 
   if (grunt.file.exists('Gemfile')) {
     grunt.config(['shell', 'bundle-install'], {
-      command: "bundle install --binstubs=gems/bin"
+      command: "bundle install --binstubs=bin --path=vendor/bundle"
     });
     grunt.registerTask('bundleInstall', ['shell:bundle-install']);
     grunt.registerTask('bundle-install', ['shell:bundle-install']);


### PR DESCRIPTION
Changing bundle install default options to install gems to vendor/bundle/ and binaries to bin/.