### PR TITLE
Implement push instead of pull-based approach to help

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -324,22 +324,36 @@ this format, see: http://gruntjs.com/configuring-tasks#files
 from the project directory when building a package. The above includes README
 files and files under bin/ in the project's package.
 
-### Help Settings
+### Help Settings (Help API)
 
 If you add custom tasks to your project and want them exposed as part of the
-`help` task, you may add the following configuration to your `Gruntconfig.json`
-on a per task basis:
+`help` task, you may add a simple code snippet to your Gruntfile.js or any loaded
+task file.
 
-```
-{
-  "help": {
-    "task-name": {
-      "group": "Include Task in this Named Group",
-      "description": "Optional description that overrides the default description you would see in `grunt -h`"
-    }
+```js
+var Help = require('grunt-drupal-tasks/lib/help');
+
+Help.addItem('existing-task', 'Named Group', 'Optional description that avoids the default task description.');
+
+Help.add({
+  task: 'existing-task',
+  group: 'Named Group',
+  description: 'Optional description that avoids the default task description.'
+});
+
+Help.add([
+  {
+    task: 'existing-task',
+    group: 'Named Group',
+    description: 'Optional description that avoids the default task description.'
+  },
+  {
+    task: 'second-task',
+    group: 'Named Group',
+    description: 'A second registered task to register with the help system.'
   }
-}
+]);
 ```
 
-If you want to include your task in one of the existing groupings, copy the text
+If you want to include your task in one of the existing groups, copy the text
 exactly as seen in the output of the `grunt help` task.

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -5,12 +5,6 @@ module.exports = function(grunt) {
     config: config
   });
 
-  // Allow Gruntconfig.json to set default descriptions.
-  // tasks/zzz_help.js checks the root 'help' config namespace.
-  if (config.help) {
-    grunt.config('help', config.help);
-  }
-
   // Wrap Grunt's loadNpmTasks() function to change the current directory to
   // grunt-drupal-tasks, so that module dependencies of it are found.
   grunt._loadNpmTasks = grunt.loadNpmTasks;

--- a/lib/gdt.js
+++ b/lib/gdt.js
@@ -1,5 +1,0 @@
-module.exports = function(grunt) {
-  return {
-    help: require('./help')(grunt)
-  };
-}

--- a/lib/gdt.js
+++ b/lib/gdt.js
@@ -1,0 +1,5 @@
+module.exports = function(grunt) {
+  return {
+    help: require('./help')(grunt)
+  };
+}

--- a/lib/help.js
+++ b/lib/help.js
@@ -1,0 +1,44 @@
+module.exports = function(grunt) {
+  var module = {};
+
+  module.addItem = function(task, group, description) {
+    // Add task to the list of those displayed by `grunt help`.
+    var tasks = grunt.config('availabletasks.help.options.tasks');
+    if (tasks === undefined) {
+      tasks = [];
+    }
+    tasks.push(task);
+    grunt.config('availabletasks.help.options.tasks', tasks);
+
+    // Assign the task to the specified group.
+    if (group) {
+      var groups = grunt.config('availabletasks.help.options.groups');
+      if (groups === undefined) {
+        groups = {};
+      }
+      if (groups[group] === undefined ) {
+        groups[group] = [];
+      }
+      groups[group].push(task);
+      grunt.config('availabletasks.help.options.groups', groups);
+    }
+
+    // Override the task description.
+    if (description) {
+      grunt.config('availabletasks.help.options.descriptions.' + task, description);
+    }
+  };
+
+  module.add = function(items) {
+    if (items instanceof Array) {
+      items.forEach(function(item) {
+        module.addItem(item.task, item.group, item.description);
+      });
+    }
+    else if (items instanceof Object) {
+      module.addItem(items.task, items.group, items.description)
+    }
+  };
+
+  return module;
+};

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "grunt-phpmd": "0.1.1",
     "grunt-shell": "1.1.1",
     "lodash": "2.4.1",
-    "require-directory": "^2.0.0",
     "time-grunt": "1.0.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "grunt-phpmd": "0.1.1",
     "grunt-shell": "1.1.1",
     "lodash": "2.4.1",
+    "require-directory": "^2.0.0",
     "time-grunt": "1.0.0"
   },
   "peerDependencies": {

--- a/tasks/behat.js
+++ b/tasks/behat.js
@@ -24,6 +24,7 @@ module.exports = function(grunt) {
    *   }
    */
   grunt.loadNpmTasks('grunt-parallel-behat');
+  var GDT = require('../lib/gdt')(grunt);
 
   var config = grunt.config.get('config'),
     flags = '',
@@ -69,7 +70,8 @@ module.exports = function(grunt) {
 
     grunt.registerTask('test', ['behat']);
 
-    grunt.config('help.test', {
+    GDT.help.add({
+      task: 'test',
       group: 'Testing & Code Quality',
       description: 'Run the Behat tests included with this project.'
     });

--- a/tasks/behat.js
+++ b/tasks/behat.js
@@ -24,7 +24,7 @@ module.exports = function(grunt) {
    *   }
    */
   grunt.loadNpmTasks('grunt-parallel-behat');
-  var GDT = require('../lib/gdt')(grunt);
+  var Help = require('../lib/help')(grunt);
 
   var config = grunt.config.get('config'),
     flags = '',
@@ -70,7 +70,7 @@ module.exports = function(grunt) {
 
     grunt.registerTask('test', ['behat']);
 
-    GDT.help.add({
+    Help.add({
       task: 'test',
       group: 'Testing & Code Quality',
       description: 'Run the Behat tests included with this project.'

--- a/tasks/bundler.js
+++ b/tasks/bundler.js
@@ -7,7 +7,7 @@ module.exports = function(grunt) {
    * "bundle install".
    */
   grunt.loadNpmTasks('grunt-shell');
-  var GDT = require('../lib/gdt')(grunt);
+  var Help = require('../lib/help')(grunt);
 
   if (grunt.file.exists('Gemfile')) {
     grunt.config(['shell', 'bundle-install'], {
@@ -16,7 +16,7 @@ module.exports = function(grunt) {
     grunt.registerTask('bundleInstall', ['shell:bundle-install']);
     grunt.registerTask('bundle-install', ['shell:bundle-install']);
 
-    GDT.help.add({
+    Help.add({
       task: 'bundle-install',
       group: 'Dependency Management',
       description: 'Run `bundle install`, dropping symlinks to all binaries in `gems/bin`.'

--- a/tasks/bundler.js
+++ b/tasks/bundler.js
@@ -7,6 +7,7 @@ module.exports = function(grunt) {
    * "bundle install".
    */
   grunt.loadNpmTasks('grunt-shell');
+  var GDT = require('../lib/gdt')(grunt);
 
   if (grunt.file.exists('Gemfile')) {
     grunt.config(['shell', 'bundle-install'], {
@@ -15,7 +16,8 @@ module.exports = function(grunt) {
     grunt.registerTask('bundleInstall', ['shell:bundle-install']);
     grunt.registerTask('bundle-install', ['shell:bundle-install']);
 
-    grunt.config('help.bundle-install', {
+    GDT.help.add({
+      task: 'bundle-install',
       group: 'Dependency Management',
       description: 'Run `bundle install`, dropping symlinks to all binaries in `gems/bin`.'
     });

--- a/tasks/clean.js
+++ b/tasks/clean.js
@@ -10,7 +10,7 @@ module.exports = function(grunt) {
    *   Removes sites/default in the build/html directory.
    */
   grunt.loadNpmTasks('grunt-contrib-clean');
-  var GDT = require('../lib/gdt')(grunt);
+  var Help = require('../lib/help')(grunt);
 
   grunt.config('clean', {
     default: [
@@ -24,7 +24,7 @@ module.exports = function(grunt) {
     ]
   });
 
-  GDT.help.add({
+  Help.add({
     task: 'clean',
     group: 'Utilities',
     description: 'Use "clean" to remove the build output directory.'

--- a/tasks/clean.js
+++ b/tasks/clean.js
@@ -10,6 +10,8 @@ module.exports = function(grunt) {
    *   Removes sites/default in the build/html directory.
    */
   grunt.loadNpmTasks('grunt-contrib-clean');
+  var GDT = require('../lib/gdt')(grunt);
+
   grunt.config('clean', {
     default: [
       '<%= config.buildPaths.html %>'
@@ -22,7 +24,8 @@ module.exports = function(grunt) {
     ]
   });
 
-  grunt.config('help.clean', {
+  GDT.help.add({
+    task: 'clean',
     group: 'Utilities',
     description: 'Use "clean" to remove the build output directory.'
   });

--- a/tasks/composer.js
+++ b/tasks/composer.js
@@ -9,11 +9,11 @@ module.exports = function(grunt) {
   var config = grunt.config.get('config');
   if (require('fs').existsSync('./composer.json')) {
     grunt.loadNpmTasks('grunt-composer');
-    var GDT = require('../lib/gdt')(grunt);
+    var Help = require('../lib/help')(grunt);
 
     grunt.config(['composer', 'install'], {});
 
-    GDT.help.add({
+    Help.add({
       task: 'composer',
       group: 'Dependency Management',
       description: 'Install dependencies defined in this project\'s composer.json file.'

--- a/tasks/composer.js
+++ b/tasks/composer.js
@@ -6,11 +6,15 @@ module.exports = function(grunt) {
    * Dynamically adds a Composer install task if a composer.json file
    * exists in the project directory.
    */
-  grunt.loadNpmTasks('grunt-composer');
   var config = grunt.config.get('config');
   if (require('fs').existsSync('./composer.json')) {
+    grunt.loadNpmTasks('grunt-composer');
+    var GDT = require('../lib/gdt')(grunt);
+
     grunt.config(['composer', 'install'], {});
-    grunt.config('help.composer', {
+
+    GDT.help.add({
+      task: 'composer',
       group: 'Dependency Management',
       description: 'Install dependencies defined in this project\'s composer.json file.'
     });

--- a/tasks/drush.js
+++ b/tasks/drush.js
@@ -8,7 +8,7 @@ module.exports = function(grunt) {
    */
   grunt.loadNpmTasks('grunt-drush');
   grunt.loadNpmTasks('grunt-newer');
-  var GDT = require('../lib/gdt')(grunt);
+  var Help = require('../lib/help')(grunt);
 
   // Provide a default path for drush.
   var cmd = grunt.config('config.drush.cmd') || process.cwd() + '/bin/drush';
@@ -60,7 +60,7 @@ module.exports = function(grunt) {
     }
   });
 
-  GDT.help.add([
+  Help.add([
     {
       task: 'drushmake',
       group: 'Dependency Management'

--- a/tasks/drush.js
+++ b/tasks/drush.js
@@ -8,6 +8,7 @@ module.exports = function(grunt) {
    */
   grunt.loadNpmTasks('grunt-drush');
   grunt.loadNpmTasks('grunt-newer');
+  var GDT = require('../lib/gdt')(grunt);
 
   // Provide a default path for drush.
   var cmd = grunt.config('config.drush.cmd') || process.cwd() + '/bin/drush';
@@ -59,11 +60,15 @@ module.exports = function(grunt) {
     }
   });
 
-  grunt.config('help.drushmake', {
-    group: 'Dependency Management'
-  });
-  grunt.config('help.newer', {
-    group: 'Dependency Management',
-    description: 'Use "newer:drushmake" to run the drushmake task only if the make file was updated.'
-  });
+  GDT.help.add([
+    {
+      task: 'drushmake',
+      group: 'Dependency Management'
+    },
+    {
+      task: 'newer',
+      group: 'Dependency Management',
+      description: 'Use "newer:drushmake" to run the drushmake task only if the make file was updated.'
+    }
+  ]);
 };

--- a/tasks/help.js
+++ b/tasks/help.js
@@ -8,21 +8,15 @@ module.exports = function(grunt) {
    */
 
   grunt.loadNpmTasks('grunt-available-tasks');
-  var gdt = require('../lib/gdt')(grunt);
+  var GDT = require('../lib/gdt')(grunt);
 
-  gdt.help.add({
+  GDT.help.add({
     task: 'default',
     group: 'Build Process',
     description: 'The default build process that executes when "grunt" runs, which includes verifying dependencies and assembling the build directory.'
   });
 
-  grunt.config(['availabletasks', 'help'], {
-    options: {
-      filter: 'include',
-    }
-  });
-
-  console.log(gdt);
+  grunt.config('availabletasks.help.options.filter', 'include');
 
   grunt.registerTask('help', ['availabletasks:help']);
 };

--- a/tasks/help.js
+++ b/tasks/help.js
@@ -8,9 +8,9 @@ module.exports = function(grunt) {
    */
 
   grunt.loadNpmTasks('grunt-available-tasks');
-  var GDT = require('../lib/gdt')(grunt);
+  var Help = require('../lib/help')(grunt);
 
-  GDT.help.add({
+  Help.add({
     task: 'default',
     group: 'Build Process',
     description: 'The default build process that executes when "grunt" runs, which includes verifying dependencies and assembling the build directory.'

--- a/tasks/help.js
+++ b/tasks/help.js
@@ -8,38 +8,21 @@ module.exports = function(grunt) {
    */
 
   grunt.loadNpmTasks('grunt-available-tasks');
+  var gdt = require('../lib/gdt')(grunt);
 
-  grunt.config('help.default', {
+  gdt.help.add({
+    task: 'default',
     group: 'Build Process',
     description: 'The default build process that executes when "grunt" runs, which includes verifying dependencies and assembling the build directory.'
-  });
-
-  var help = grunt.config.get('help'),
-    items = Object.keys(help),
-    descriptions = {},
-    groups = {};
-
-  items.forEach(function(item) {
-    if (help[item]['description']) {
-      descriptions[item] = help[item]['description'];
-    }
-    if (help[item]['group']) {
-      var groupName = help[item]['group'];
-      if (groups[groupName] == undefined) {
-        groups[groupName] = [];
-      }
-      groups[groupName].push(item);
-    }
   });
 
   grunt.config(['availabletasks', 'help'], {
     options: {
       filter: 'include',
-      tasks: Object.keys(help),
-      descriptions: descriptions,
-      groups: groups
     }
   });
+
+  console.log(gdt);
 
   grunt.registerTask('help', ['availabletasks:help']);
 };

--- a/tasks/package.js
+++ b/tasks/package.js
@@ -7,7 +7,7 @@ module.exports = function(grunt) {
    *   Builds a deployment package in the build/package directory.
    */
   grunt.loadNpmTasks('grunt-contrib-compress');
-  var GDT = require('../lib/gdt')(grunt);
+  var Help = require('../lib/help')(grunt);
 
   var config = grunt.config.get('config'),
     srcFiles = (config.packages && config.packages.srcFiles && config.packages.srcFiles.length) ? config.packages.srcFiles : [],
@@ -45,7 +45,7 @@ module.exports = function(grunt) {
     grunt.task.run(this.data);
   });
 
-  GDT.help.add({
+  Help.add({
     task: 'package',
     group: 'Operations'
   });

--- a/tasks/package.js
+++ b/tasks/package.js
@@ -7,9 +7,12 @@ module.exports = function(grunt) {
    *   Builds a deployment package in the build/package directory.
    */
   grunt.loadNpmTasks('grunt-contrib-compress');
+  var GDT = require('../lib/gdt')(grunt);
+
   var config = grunt.config.get('config'),
     srcFiles = (config.packages && config.packages.srcFiles && config.packages.srcFiles.length) ? config.packages.srcFiles : [],
     projFiles = (config.packages && config.packages.projFiles && config.packages.projFiles.length) ? config.packages.projFiles : [];
+
   grunt.config('compress', {
     package: {
       options: {
@@ -42,7 +45,8 @@ module.exports = function(grunt) {
     grunt.task.run(this.data);
   });
 
-  grunt.config('help.package', {
+  GDT.help.add({
+    task: 'package',
     group: 'Operations'
   });
 };

--- a/tasks/quality.js
+++ b/tasks/quality.js
@@ -16,6 +16,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-phplint');
   grunt.loadNpmTasks('grunt-phpcs');
   grunt.loadNpmTasks('grunt-phpmd');
+  var GDT = require('../lib/gdt')(grunt);
 
   // Task set aliases are registered at the end of the file based on these values.
   var validate = [];
@@ -126,12 +127,16 @@ module.exports = function(grunt) {
     grunt.registerTask('analyze', ['concurrent:analyze']);
   }
 
-  grunt.config('help.validate', {
-    group: 'Testing & Code Quality',
-    description: 'Quick code health check for syntax errors and basic practices. (e.g. PHPCS w/ Drush Coder rules)'
-  });
-  grunt.config('help.analyze', {
-    group: 'Testing & Code Quality',
-    description: 'Static codebase analysis to detect problems. Outputs Jenkins-compatible reports. (e.g. PHPMD)'
-  });
+  GDT.help.add([
+    {
+      task: 'validate',
+      group: 'Testing & Code Quality',
+      description: 'Quick code health check for syntax errors and basic practices. (e.g. PHPCS w/ Drush Coder rules)'
+    },
+    {
+      task: 'analyze',
+      group: 'Testing & Code Quality',
+      description: 'Static codebase analysis to detect problems. Outputs Jenkins-compatible reports. (e.g. PHPMD)'
+    }
+  ]);
 };

--- a/tasks/quality.js
+++ b/tasks/quality.js
@@ -16,7 +16,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-phplint');
   grunt.loadNpmTasks('grunt-phpcs');
   grunt.loadNpmTasks('grunt-phpmd');
-  var GDT = require('../lib/gdt')(grunt);
+  var Help = require('../lib/help')(grunt);
 
   // Task set aliases are registered at the end of the file based on these values.
   var validate = [];
@@ -127,7 +127,7 @@ module.exports = function(grunt) {
     grunt.registerTask('analyze', ['concurrent:analyze']);
   }
 
-  GDT.help.add([
+  Help.add([
     {
       task: 'validate',
       group: 'Testing & Code Quality',

--- a/tasks/theme.js
+++ b/tasks/theme.js
@@ -26,14 +26,15 @@ module.exports = function(grunt) {
    * }
    */
 
-  grunt.loadNpmTasks('grunt-contrib-compass');
-
   var config = grunt.config.get('config'),
     _ = require('lodash'),
     steps = [],
     parallelTasks = [];
 
   if (config.themes) {
+    grunt.loadNpmTasks('grunt-contrib-compass');
+    var GDT = require('../lib/gdt')(grunt);
+
     for (var key in config.themes) {
       if (config.themes.hasOwnProperty(key) && config.themes[key].compass) {
         var theme = config.themes[key],
@@ -72,7 +73,8 @@ module.exports = function(grunt) {
       });
 
       grunt.registerTask('watch-theme', ['concurrent:watch-theme']);
-      grunt.config('help.watch-theme', {
+      GDT.help.add({
+        task: 'watch-theme',
         group: 'Real-time Tooling',
         description: "Watch for changes that should rebuild frontend assets, such as CSS."
       });
@@ -80,7 +82,8 @@ module.exports = function(grunt) {
 
     if (steps) {
       grunt.registerTask('compile-theme', steps);
-      grunt.config('help.compile-theme', {
+      GDT.help.add({
+        task: 'compile-theme',
         group: 'Asset & Code Compilation',
         description: 'Run compilers for the theme, such as Compass.'
       });

--- a/tasks/theme.js
+++ b/tasks/theme.js
@@ -33,7 +33,7 @@ module.exports = function(grunt) {
 
   if (config.themes) {
     grunt.loadNpmTasks('grunt-contrib-compass');
-    var GDT = require('../lib/gdt')(grunt);
+    var Help = require('../lib/help')(grunt);
 
     for (var key in config.themes) {
       if (config.themes.hasOwnProperty(key) && config.themes[key].compass) {
@@ -73,7 +73,7 @@ module.exports = function(grunt) {
       });
 
       grunt.registerTask('watch-theme', ['concurrent:watch-theme']);
-      GDT.help.add({
+      Help.add({
         task: 'watch-theme',
         group: 'Real-time Tooling',
         description: "Watch for changes that should rebuild frontend assets, such as CSS."
@@ -82,7 +82,7 @@ module.exports = function(grunt) {
 
     if (steps) {
       grunt.registerTask('compile-theme', steps);
-      GDT.help.add({
+      Help.add({
         task: 'compile-theme',
         group: 'Asset & Code Compilation',
         description: 'Run compilers for the theme, such as Compass.'

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -8,6 +8,7 @@ module.exports = function(grunt) {
    * a file in the testing features directory changes.
    */
   grunt.loadNpmTasks('grunt-contrib-watch');
+  var GDT = require('../lib/gdt')(grunt);
 
   grunt.config(['watch', 'test'], {
     files: [
@@ -38,8 +39,9 @@ module.exports = function(grunt) {
     grunt.task.run('concurrent:watch-test');
   });
 
-  grunt.config('help.watch-test', {
+  GDT.help.add({
+    task: 'watch-test',
     group: 'Real-time Tooling',
-    description: "Watch for changes that should trigger new testing and validation of the codebase."
+    description: 'Watch for changes that should trigger new testing and validation of the codebase.'
   });
 }

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -8,7 +8,7 @@ module.exports = function(grunt) {
    * a file in the testing features directory changes.
    */
   grunt.loadNpmTasks('grunt-contrib-watch');
-  var GDT = require('../lib/gdt')(grunt);
+  var Help = require('../lib/help')(grunt);
 
   grunt.config(['watch', 'test'], {
     files: [
@@ -39,7 +39,7 @@ module.exports = function(grunt) {
     grunt.task.run('concurrent:watch-test');
   });
 
-  GDT.help.add({
+  Help.add({
     task: 'watch-test',
     group: 'Real-time Tooling',
     description: 'Watch for changes that should trigger new testing and validation of the codebase.'


### PR DESCRIPTION
Fixed #118 

This branch removes most of the code from what was tasks/zzz_help.js and instead defines a small library module that provides a means for any other code loaded by grunt to push help content into the availabletasks plugin before the task is executed.

This also demonstrates a GDT helper module loader pattern so we don't need lots of requires everywhere. I think we may be able to do something clever like attaching gdt to grunt in bootstrap, but I thought to leave that notion alone for now.

Note that this still needs a documentation update, and completely discards both the pull-based mechanism we had before, as well as the more recent Gruntconfig-based help. I think it's reasonable to put back the Gruntconfig help if we want it, but would kind of like to just drop it as this is much more flexible and not that much more complicated for projects to implement.