### PR TITLE
Task/minimize config buildpaths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Ruby (bundler) will now install dependencies into `vendor/bundle`.
 - Ruby and PHP upstream binaries are placed or symlinked from `vendor/bin`.
   This frees up `bin/` for custom project scripts.
+- Moving more default Gruntconfig.json into code for a slimmer project Gruntconfig.
 
 ### Upgrade Notes
 
@@ -12,7 +13,8 @@
   scripts, you should be fine.
 - You may need to run `rm -Rf .bundle` to clear bundler configuration to make
   way for the new install location.
-
+- Gruntconfig.json no longer needs the `buildPaths` config key. Elements of
+  `buildPaths` added to your project Gruntconfig will override default behavior.
 
 ## v0.5.2 [2015/01/24]
 

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -1,3 +1,5 @@
+var _ = require('lodash');
+
 module.exports = function(grunt) {
   // Initialize global configuration variables.
   var config = grunt.file.readJSON('Gruntconfig.json');
@@ -10,6 +12,17 @@ module.exports = function(grunt) {
   if (config.help) {
     grunt.config('help', config.help);
   }
+
+  // Set implicit global configuration.
+  var buildPaths = grunt.config('config.buildPaths');
+  buildPaths = _.extend({
+    build: 'build',
+    html: 'build/html',
+    package: 'build/packages',
+    reports: 'build/reports',
+    temp: 'build/temp'
+  });
+  grunt.config('config.buildPaths', buildPaths);
 
   // Wrap Grunt's loadNpmTasks() function to change the current directory to
   // grunt-drupal-tasks, so that module dependencies of it are found.

--- a/example/Gruntconfig.json
+++ b/example/Gruntconfig.json
@@ -3,13 +3,6 @@
     "make": "src/project.make",
     "drupal": "src"
   },
-  "buildPaths": {
-    "build": "build",
-    "html": "build/html",
-    "package": "build/packages",
-    "reports": "build/reports",
-    "temp": "build/temp"
-  },
   "siteUrls": {
     "default": "http://project.local"
   },

--- a/tasks/quality.js
+++ b/tasks/quality.js
@@ -123,7 +123,8 @@ module.exports = function(grunt) {
         logConcurrentOutput: true
       }
     });
-    grunt.registerTask('analyze', ['concurrent:analyze']);
+
+    grunt.registerTask('analyze', ['mkdir:init', 'concurrent:analyze']);
   }
 
   grunt.config('help.validate', {

--- a/test/test_assets/Gruntconfig.json
+++ b/test/test_assets/Gruntconfig.json
@@ -3,13 +3,6 @@
     "make": "src/project.make",
     "drupal": "src"
   },
-  "buildPaths": {
-    "build": "build",
-    "html": "build/html",
-    "package": "build/packages",
-    "reports": "build/reports",
-    "temp": "build/temp"
-  },
   "siteUrls": {
     "default": "http://project.local"
   },


### PR DESCRIPTION
Moves the buildPaths config into implicit as part of the bootstrap.js

While I was in there, I also added a quick mkdir:init before analyze, as currently if you run analyze without having built the site it chokes on the lack of build/reports.