### PR TITLE
Switch to using composer to build drupal instead of drush make.

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -34,7 +34,6 @@ module.exports = function(grunt) {
   // Define the default task to fully build and configure the project.
   var tasksDefault = [
     'validate',
-    'newer:composerinstall',
     'symlink:profiles',
     'symlink:modules',
     'symlink:themes',
@@ -44,6 +43,12 @@ module.exports = function(grunt) {
     'mkdir:files',
     'copy:static'
   ];
+  if (grunt.config.get(['composer', 'install'])) {
+    tasksDefault.splice(1, 0, 'newer:composerinstall');
+  }
+  if (grunt.config(['srcPaths.make'])) {
+    tasksDefault.splice(1, 0, 'newer:drushmake:default');
+  }
   if (grunt.task.exists('bundle-install')) {
     tasksDefault.unshift('bundle-install');
   }

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -34,7 +34,7 @@ module.exports = function(grunt) {
   // Define the default task to fully build and configure the project.
   var tasksDefault = [
     'validate',
-    'newer:drushmake:default',
+    'newer:composerinstall',
     'symlink:profiles',
     'symlink:modules',
     'symlink:themes',
@@ -44,9 +44,6 @@ module.exports = function(grunt) {
     'mkdir:files',
     'copy:static'
   ];
-  if (grunt.config.get(['composer', 'install'])) {
-    tasksDefault.unshift('composer:install');
-  }
   if (grunt.task.exists('bundle-install')) {
     tasksDefault.unshift('bundle-install');
   }

--- a/example/composer.json
+++ b/example/composer.json
@@ -1,15 +1,44 @@
 {
-    "name": "client/project",
-    "description": "{Project} drupal codebase for {client}.",
-    "require-dev": {
-        "behat/mink-zombie-driver": "~1.2",
-        "drupal/drupal-extension": "~3.0",
-        "drush/drush": "dev-master",
-        "phpmd/phpmd": "~2.1",
-        "squizlabs/php_codesniffer": "~1.5",
-        "drupal/coder": "7.2.3"
+  "name": "client/project",
+  "description": "{Project} drupal codebase for {client}.",
+  "repositories": [{
+    "type": "composer",
+    "url": "http://packagist.drupal-composer.org"
+  }],
+  "require": {
+    "roave/security-advisories": "dev-master",
+    "composer/installers": "~1.0",
+    "derhasi/composer-preserve-paths": "0.1.*",
+    "drupal/drupal": "7.*",
+    "drupal/features": "~7.2"
+  },
+  "require-dev": {
+    "behat/mink-zombie-driver": "~1.2",
+    "drupal/drupal-extension": "~3.0",
+    "drush/drush": "dev-master",
+    "phpmd/phpmd": "~2.1",
+    "squizlabs/php_codesniffer": "~1.5",
+    "drupal/coder": "7.2.3"
+  },
+  "config": {
+    "vendor-dir": "vendor"
+  },
+  "extra": {
+    "installer-paths": {
+      "build/html/": ["type:drupal-core"],
+      "build/html/sites/all/modules/contrib/{$name}/": ["type:drupal-module"],
+      "build/html/sites/all/themes/{$name}/": ["type:drupal-theme"],
+      "build/html/sites/all/libraries/{$name}/": ["type:drupal-library"],
+      "build/html/sites/all/drush/{$name}/": ["type:drupal-drush"],
+      "build/html/profiles/{$name}/": ["type:drupal-profile"]
     },
-    "require": {
-        "roave/security-advisories": "dev-master"
-    }
+    "preserve-paths": [
+      "build/html/sites/all/modules/contrib",
+      "build/html/sites/all/themes",
+      "build/html/sites/all/libraries",
+      "build/html/sites/all/drush",
+      "build/html/sites/default/settings.php",
+      "build/html/sites/default/files"
+    ]
+  }
 }

--- a/tasks/composer.js
+++ b/tasks/composer.js
@@ -7,6 +7,7 @@ module.exports = function(grunt) {
    * exists in the project directory.
    */
   var config = grunt.config.get('config');
+  grunt.loadNpmTasks('grunt-newer');
   if (require('fs').existsSync('./composer.json')) {
     grunt.loadNpmTasks('grunt-composer');
     var Help = require('../lib/help')(grunt);
@@ -18,5 +19,30 @@ module.exports = function(grunt) {
       group: 'Dependency Management',
       description: 'Install dependencies defined in this project\'s composer.json file.'
     });
+
+    grunt.registerTask('composerinstall', 'Prepare the build directory and run "composer install"', function() {
+      grunt.task.run('mkdir:init', 'clean:temp', 'composer:install', 'clean:default', 'copy:tempbuild', 'clean:temp');
+    });
+
+    // The "composerinstall" task will run make only if the src file specified here is
+    // newer than the dest file specified.
+    grunt.config('composerinstall', {
+      default: {
+        src: './composer.json',
+        dest: '<%= config.buildPaths.html %>'
+      }
+    });
+
+    Help.add([
+      {
+        task: 'composerinstall',
+        group: 'Dependency Management'
+      },
+      {
+        task: 'newer',
+        group: 'Dependency Management',
+        description: 'Use "newer:composerinstall" to run the composerinstall task only if the composer.json file was updated.'
+      }
+    ]);
   }
 };

--- a/tasks/composer.js
+++ b/tasks/composer.js
@@ -28,6 +28,7 @@ module.exports = function(grunt) {
     // newer than the dest file specified.
     grunt.config('composerinstall', {
       default: {
+        args: [],
         src: './composer.json',
         dest: '<%= config.buildPaths.html %>'
       }

--- a/tasks/drush.js
+++ b/tasks/drush.js
@@ -2,8 +2,12 @@ module.exports = function(grunt) {
 
   /**
    * Define "drush" tasks.
+   *
+   * grunt drush:make
+   *   Builds the Drush make file to the build/html directory.
    */
   grunt.loadNpmTasks('grunt-drush');
+  grunt.loadNpmTasks('grunt-newer');
   var Help = require('../lib/help')(grunt);
 
   var path = require('path'),
@@ -12,7 +16,21 @@ module.exports = function(grunt) {
   // If no path is configured for Drush, fallback to the system path.
   var cmd = grunt.config('config.drush.cmd') !== undefined ? {cmd: path.resolve(grunt.config('config.drush.cmd'))} : {};
 
+  // Allow extra arguments for drush to be supplied.
+  var args = ['make', '<%= config.srcPaths.make %>', '<%= config.buildPaths.temp %>'],
+    extra_args = grunt.config.get('config.drush.make.args');
+  if (extra_args && extra_args.length) {
+    extra_args.unshift(args[0]);
+    extra_args.push(args[1]);
+    extra_args.push(args[2]);
+    args = extra_args;
+  }
+
   grunt.config('drush', {
+    make: {
+      args: args,
+      options: _.extend({}, cmd)
+    },
     liteinstall: {
       args: ['site-install', '-y', 'standard', '--db-url=sqlite://drupal:drupal@drupal.sqlite'],
       options: _.extend({
@@ -26,4 +44,30 @@ module.exports = function(grunt) {
       }, cmd)
     }
   });
+
+  grunt.registerTask('drushmake', 'Prepare the build directory and run "drush make"', function() {
+    grunt.task.run('mkdir:init', 'clean:temp', 'drush:make', 'clean:default', 'copy:tempbuild', 'clean:temp');
+  });
+
+  // The "drushmake" task will run make only if the src file specified here is
+  // newer than the dest file specified. This includes all make files in the
+  // source directory to catch make files included from the primary one.
+  grunt.config('drushmake', {
+    default: {
+      src: ['<%= config.srcPaths.make %>', '<%= config.srcPaths.drupal %>/**/*.make'],
+      dest: '<%= config.buildPaths.html %>'
+    }
+  });
+
+  Help.add([
+    {
+      task: 'drushmake',
+      group: 'Dependency Management'
+    },
+    {
+      task: 'newer',
+      group: 'Dependency Management',
+      description: 'Use "newer:drushmake" to run the drushmake task only if the make file was updated.'
+    }
+  ]);
 };

--- a/tasks/drush.js
+++ b/tasks/drush.js
@@ -2,12 +2,8 @@ module.exports = function(grunt) {
 
   /**
    * Define "drush" tasks.
-   *
-   * grunt drush:make
-   *   Builds the Drush make file to the build/html directory.
    */
   grunt.loadNpmTasks('grunt-drush');
-  grunt.loadNpmTasks('grunt-newer');
   var Help = require('../lib/help')(grunt);
 
   var path = require('path'),
@@ -16,21 +12,7 @@ module.exports = function(grunt) {
   // If no path is configured for Drush, fallback to the system path.
   var cmd = grunt.config('config.drush.cmd') !== undefined ? {cmd: path.resolve(grunt.config('config.drush.cmd'))} : {};
 
-  // Allow extra arguments for drush to be supplied.
-  var args = ['make', '<%= config.srcPaths.make %>', '<%= config.buildPaths.temp %>'],
-    extra_args = grunt.config.get('config.drush.make.args');
-  if (extra_args && extra_args.length) {
-    extra_args.unshift(args[0]);
-    extra_args.push(args[1]);
-    extra_args.push(args[2]);
-    args = extra_args;
-  }
-
   grunt.config('drush', {
-    make: {
-      args: args,
-      options: _.extend({}, cmd)
-    },
     liteinstall: {
       args: ['site-install', '-y', 'standard', '--db-url=sqlite://drupal:drupal@drupal.sqlite'],
       options: _.extend({
@@ -44,30 +26,4 @@ module.exports = function(grunt) {
       }, cmd)
     }
   });
-
-  grunt.registerTask('drushmake', 'Prepare the build directory and run "drush make"', function() {
-    grunt.task.run('mkdir:init', 'clean:temp', 'drush:make', 'clean:default', 'copy:tempbuild', 'clean:temp');
-  });
-
-  // The "drushmake" task will run make only if the src file specified here is
-  // newer than the dest file specified. This includes all make files in the
-  // source directory to catch make files included from the primary one.
-  grunt.config('drushmake', {
-    default: {
-      src: ['<%= config.srcPaths.make %>', '<%= config.srcPaths.drupal %>/**/*.make'],
-      dest: '<%= config.buildPaths.html %>'
-    }
-  });
-
-  Help.add([
-    {
-      task: 'drushmake',
-      group: 'Dependency Management'
-    },
-    {
-      task: 'newer',
-      group: 'Dependency Management',
-      description: 'Use "newer:drushmake" to run the drushmake task only if the make file was updated.'
-    }
-  ]);
 };


### PR DESCRIPTION
With https://github.com/drupal-composer/drupal-project we could remove the dependency on drush make and use composer to install drupal instead. This would decrease the number of package managers being used to 3 (npm, composer, gem/bundler).