### PR TITLE
Merge defaults for buildpath correctly

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -15,7 +15,7 @@ module.exports = function(grunt) {
     package: 'build/packages',
     reports: 'build/reports',
     temp: 'build/temp'
-  });
+  }, buildPaths);
   grunt.config('config.buildPaths', buildPaths);
 
   // Wrap Grunt's loadNpmTasks() function to change the current directory to


### PR DESCRIPTION
This snippet currently overwrites any settings specified in Gruntconfig.json. [lodash documentation](https://github.com/lodash/lodash/blob/2.4.1/doc/README.md#_assignobject-source-callback-thisarg)