### PR TITLE
Ignore vendor folder on lint

### DIFF
--- a/tasks/quality.js
+++ b/tasks/quality.js
@@ -33,7 +33,8 @@ module.exports = function(grunt) {
     '!<%= config.srcPaths.drupal %>/**/*.features.*inc',
     '!<%= config.srcPaths.drupal %>/**/*.pages_default.inc',
     '!<%= config.srcPaths.drupal %>/**/*.panelizer.inc',
-    '!<%= config.srcPaths.drupal %>/**/*.strongarm.inc'
+    '!<%= config.srcPaths.drupal %>/**/*.strongarm.inc',
+    '!<%= config.srcPaths.drupal %>/**/vendor/**'
   ];
 
   grunt.config('phplint', {


### PR DESCRIPTION
When doing lint, if a site is using composer locally, lint will fail on packages.

Example:
```
 ┌┤fredric@jonstewart:130 [Mar 26 16:48:21] ~/ (master) $ 
 └╼ grunt
Running "notify_hooks" task

Running "composer:install" (composer) task
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Nothing to install or update
Generating autoload files

Running "phplint:all" (phplint) task
Warning: 
Fatal error: Cannot redeclare iconv() in src/modules/my_module/vendor/patchwork/utf8/class/Patchwork/Utf8/Bootup/iconv.php on line 18
Errors parsing src/modules/my_module/vendor/patchwork/utf8/class/Patchwork/Utf8/Bootup/iconv.php Use --force to continue.

Aborted due to warnings.
```