### PR TITLE
Updating db-url for the drush:liteinstall

### DIFF
--- a/tasks/drush.js
+++ b/tasks/drush.js
@@ -32,7 +32,7 @@ module.exports = function(grunt) {
       options: _.extend({}, cmd)
     },
     liteinstall: {
-      args: ['site-install', '-y', 'standard', '--db-url=sqlite://drupal:drupal@drupal.sqlite'],
+      args: ['site-install', '-y', 'standard', '--db-url=sqlite:/' + path.join(path.resolve(grunt.config('config.buildPaths.build')), 'drupal.sqlite')],
       options: _.extend({
         cwd: '<%= config.buildPaths.html %>'
       }, cmd)


### PR DESCRIPTION
Updating db-url for the drush:liteinstall command to ensure the sqlite database is saved within the build directory.