### PR TITLE
Support .sass files in watch:compile-theme file scanner

### DIFF
--- a/tasks/theme.js
+++ b/tasks/theme.js
@@ -53,7 +53,8 @@ module.exports = function(grunt) {
         // Provide a watch handler
         grunt.config(['watch', 'compass-' + key], {
           files: [
-            theme.path + '/**/*.scss'
+            theme.path + '/**/*.scss',
+            theme.path + '/**/*.sass'
           ],
           tasks: ['compass:' + key]
         });

--- a/test/test_assets/src/themes/example_theme/config.rb
+++ b/test/test_assets/src/themes/example_theme/config.rb
@@ -17,4 +17,4 @@ javascripts_dir = "javascripts"
 # To disable debugging comments that display the original location of your selectors. Uncomment:
 # line_comments = false
 
-preferred_syntax = :sass
+preferred_syntax = :scss

--- a/test/test_assets/src/themes/example_theme/sass/ie.sass
+++ b/test/test_assets/src/themes/example_theme/sass/ie.sass
@@ -1,6 +1,0 @@
-/*
-  Welcome to Compass. Use this file to write IE specific override styles.
-  Import this file using the following HTML or equivalent:
-  <!--[if IE]>
-    <link href="/stylesheets/ie.css" media="screen, projection" rel="stylesheet" type="text/css" />
-  <![endif]-->

--- a/test/test_assets/src/themes/example_theme/sass/ie.scss
+++ b/test/test_assets/src/themes/example_theme/sass/ie.scss
@@ -1,0 +1,5 @@
+/* Welcome to Compass. Use this file to write IE specific override styles.
+ * Import this file using the following HTML or equivalent:
+ * <!--[if IE]>
+ *   <link href="/stylesheets/ie.css" media="screen, projection" rel="stylesheet" type="text/css" />
+ * <![endif]--> */

--- a/test/test_assets/src/themes/example_theme/sass/print.sass
+++ b/test/test_assets/src/themes/example_theme/sass/print.sass
@@ -1,6 +1,0 @@
-/*
-  Welcome to Compass. Use this file to define print styles.
-  Import this file using the following HTML or equivalent:
-  <link href="/stylesheets/print.css" media="print" rel="stylesheet" type="text/css" />
-  
-

--- a/test/test_assets/src/themes/example_theme/sass/print.scss
+++ b/test/test_assets/src/themes/example_theme/sass/print.scss
@@ -1,0 +1,3 @@
+/* Welcome to Compass. Use this file to define print styles.
+ * Import this file using the following HTML or equivalent:
+ * <link href="/stylesheets/print.css" media="print" rel="stylesheet" type="text/css" /> */

--- a/test/test_assets/src/themes/example_theme/sass/screen.sass
+++ b/test/test_assets/src/themes/example_theme/sass/screen.sass
@@ -1,7 +1,0 @@
-/*
-  Welcome to Compass.
-  In this file you should write your main styles. (or centralize your imports)
-  Import this file using the following HTML or equivalent:
-  <link href="/stylesheets/screen.css" media="screen, projection" rel="stylesheet" type="text/css" />
-
-@import compass/reset

--- a/test/test_assets/src/themes/example_theme/sass/screen.scss
+++ b/test/test_assets/src/themes/example_theme/sass/screen.scss
@@ -1,0 +1,6 @@
+/* Welcome to Compass.
+ * In this file you should write your main styles. (or centralize your imports)
+ * Import this file using the following HTML or equivalent:
+ * <link href="/stylesheets/screen.css" media="screen, projection" rel="stylesheet" type="text/css" /> */
+
+@import "compass/reset";


### PR DESCRIPTION
Also, switches example_theme in test/test_assets from using sass to scss.

Resolves #109.
