### PR TITLE
Upgrades to 'grunt help'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
   - npm install -g mocha
 script:
   - export PATH=$PATH:`pwd`/bin
+  - grunt help
   - grunt --timer
   - echo "Example fully built disk usage"; du -chs .
   - grunt drush:liteinstall --timer

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -53,4 +53,6 @@ module.exports = function(grunt) {
   if (grunt.option('timer')) {
     require('time-grunt')(grunt);
   }
+
+  require('grunt-log-headers')(grunt);
 };

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "grunt-contrib-symlink": "0.3.0",
     "grunt-contrib-watch": "0.6.1",
     "grunt-drush": "0.0.6",
+    "grunt-log-headers": "^1.0.1",
     "grunt-mkdir": "0.1.2",
     "grunt-newer": "1.1.0",
     "grunt-notify": "git+https://github.com/grayside/grunt-notify.git#0.5.0",

--- a/tasks/help.js
+++ b/tasks/help.js
@@ -74,7 +74,6 @@ module.exports = function(grunt) {
     var queue = [
       gruntHelp.initOptions,
       gdt.cleanOptions,
-      gruntHelp.initTasks,
       gruntHelp.initWidths,
       gruntHelp.header,
       gdt.header,

--- a/tasks/help.js
+++ b/tasks/help.js
@@ -7,7 +7,6 @@ module.exports = function(grunt) {
    *   Provides an overview of intended and useful grunt tasks.
    */
 
-  grunt.loadNpmTasks('grunt-available-tasks');
   var Help = require('../lib/help')(grunt);
 
   Help.add({
@@ -16,7 +15,76 @@ module.exports = function(grunt) {
     description: 'The default build process that executes when "grunt" runs, which includes verifying dependencies and assembling the build directory.'
   });
 
+  // Specify that only configured help entries should be displayed.
   grunt.config('availabletasks.help.options.filter', 'include');
 
-  grunt.registerTask('help', ['availabletasks:help']);
+  // Suppress task headings for help to keep it lean.
+  grunt.config('help.options.gruntLogHeader', false);
+  grunt.config('availabletasks.help.options.gruntLogHeader', false);
+  grunt.config('help-after.options.gruntLogHeader', false);
+
+  grunt.registerTask('help', 'Output grunt-drupal-tasks specialized help.', function() {
+    var gdt = {};
+    var gruntHelp = require('grunt/lib/grunt/help');
+    var process = function(queue) { queue.forEach(function(cb) { cb(); }); };
+
+    gdt.cleanOptions = function() {
+      for (var i in gruntHelp._options) {
+        item = gruntHelp._options[i];
+        if (item[0] == '--base' || item[0] == '--gruntfile' || item[0] == '--tasks' || item[0] == '--npm') delete gruntHelp._options[i];
+        if (item[0] == '--help, -h') gruntHelp._options[i][1] = 'Display the default Grunt help text.';
+      }
+    };
+
+    gdt.header = function() {
+      grunt.log.writeln('Used with Grunt Drupal Tasks (v' + require('../package.json').version + ')');
+      grunt.log.writeln().writeln('To display this help, run `grunt help`');
+    };
+
+    gdt.options = function() {
+      var options = [
+        [ '--quiet', 'Suppress desktop notifications.' ],
+        [ '--timer', 'Output task execution timing info.' ],
+        [ '--concurrency', 'Override the dynamic concurrency parameter used by Drush Make.' ]
+      ];
+      gruntHelp.table(options);
+    };
+
+    gdt.tasks = function() {
+      grunt.loadNpmTasks('grunt-available-tasks');
+      grunt.task.run('availabletasks:help', 'help-after');
+    };
+
+    gdt.footer = function() {
+      grunt.log.writeln('For help with Grunt Drupal Tasks, see ' + require('../package.json').homepage);
+    };
+
+    // Dispatch to grunt tasks is asynchronous, in order to display text after
+    // dispatching to availabletasks we need a dedicated task so grunt's internal
+    // task sequencing will ensure the proper order of execution.
+    grunt.registerTask('help-after', 'Generate a footer to follow primary help text.', function() {
+      var queue = [
+        gruntHelp.footer,
+        gdt.footer
+      ];
+
+      process(queue);
+    });
+
+    var queue = [
+      gruntHelp.initOptions,
+      gdt.cleanOptions,
+      gruntHelp.initTasks,
+      gruntHelp.initWidths,
+      gruntHelp.header,
+      gdt.header,
+      gruntHelp.usage,
+      gruntHelp.options,
+      gdt.options,
+      gruntHelp.optionsFooter,
+      gdt.tasks
+    ];
+
+    process(queue);
+  });
 };

--- a/tasks/notify.js
+++ b/tasks/notify.js
@@ -19,7 +19,9 @@ module.exports = function(grunt) {
       // configured notifyThreshold.
       success: true,
       threshold: grunt.config.get('config.notify.threshold') || 10,
-      duration: 5
+      duration: 5,
+      // Supposed to suppress notify_hooks log header, but not working.
+      gruntLogHeader: false
     }
   });
 

--- a/tasks/theme.js
+++ b/tasks/theme.js
@@ -86,7 +86,7 @@ module.exports = function(grunt) {
       Help.add({
         task: 'compile-theme',
         group: 'Asset & Code Compilation',
-        description: 'Run compilers for the theme, such as Compass.'
+        description: 'Run compilers for all themes (such as Compass).'
       });
     }
 


### PR DESCRIPTION
This change adds greater complexity and reliance on the internals of the `grunt --help` system. However, that code seems pretty stable and changes are likely to be along the line of deprecating some of our changes here. I've come to the conclusion that the better experience is worth the code debt.

I copied the [output to a fancy gist](https://gist.github.com/grayside/06c412d4018da13d46af) to facilitate review.

Fixes #65