### PR TITLE
Allow tempbuild copy to copy dot-files.

### DIFF
--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -24,7 +24,8 @@ module.exports = function(grunt) {
           expand: true,
           cwd: '<%= config.buildPaths.temp %>',
           src: ['**', '.**'],
-          dest: '<%= config.buildPaths.html %>'
+          dest: '<%= config.buildPaths.html %>',
+          dot: true
         }
       ]
     },


### PR DESCRIPTION
Tells the files glob to include dot files in all directories. The tempbuild copy process did not automatically glob dotfiles included in downloaded modules when it copies to the build destination.