### PR TITLE
Use "newer" with validate tasks in build process and watch

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -29,7 +29,7 @@ module.exports = function(grunt) {
 
   // Define the default task to fully build and configure the project.
   var tasksDefault = [
-    'validate:newer',
+    'validate',
     'newer:drushmake:default',
     'scaffold'
   ];

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -29,7 +29,7 @@ module.exports = function(grunt) {
 
   // Define the default task to fully build and configure the project.
   var tasksDefault = [
-    'validate',
+    'validate:newer',
     'newer:drushmake:default',
     'scaffold'
   ];

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "grunt-newer": "1.1.0",
     "grunt-notify": "git+https://github.com/grayside/grunt-notify.git#0.5.0",
     "grunt-parallel-behat": "0.3.6",
-    "grunt-phpcs": "git+https://github.com/grayside/grunt-phpcs.git#0.3.0",
+    "grunt-phpcs": "git+https://github.com/grayside/grunt-phpcs.git#0.5.0-fork2",
     "grunt-phplint": "0.0.5",
     "grunt-phpmd": "0.1.1",
     "grunt-shell": "1.1.2",

--- a/tasks/quality.js
+++ b/tasks/quality.js
@@ -122,7 +122,15 @@ module.exports = function(grunt) {
     }
   }
 
-  grunt.registerTask('validate', validate);
+  grunt.registerTask('validate', 'Validate the quality of custom code.', function(mode) {
+    if (mode == 'newer') {
+      var newer = validate.map(function(item) { return 'newer:' + item; });
+      grunt.task.run(newer);
+    }
+    else {
+      grunt.task.run(validate);
+    }
+  });
 
   if (analyze.length < 2) {
     grunt.registerTask('analyze', analyze);

--- a/tasks/quality.js
+++ b/tasks/quality.js
@@ -54,35 +54,42 @@ module.exports = function(grunt) {
 
     grunt.config('phpcs', {
       analyze: {
-        dir: phpcs
+        src: phpcs
       },
       drupal: {
-        dir: phpcs
+        src: phpcs
       },
       validate: {
-        dir: phpcs,
-        report: grunt.config.get('config.phpcs.validateReport') || 'full',
-        reportFile: false,
+        src: phpcs,
+        options: {
+          report: grunt.config.get('config.phpcs.validateReport') || 'full',
+          reportFile: false
+        }
       },
       full: {
-        dir: phpcs,
-        report: 'full',
-        reportFile: false
+        src: phpcs,
+        options: {
+          report: 'full',
+          reportFile: false
+        }
       },
       summary: {
-        dir: phpcs,
-        report: 'summary',
-        reportFile: false
+        src: phpcs,
+        options: {
+          report: 'summary',
+          reportFile: false
+        }
       },
       gitblame: {
-        dir: phpcs,
-        report: 'gitblame',
-        reportFile: false
+        src: phpcs,
+        options: {
+          report: 'gitblame',
+          reportFile: false
+        }
       },
       options: {
         bin: '<%= config.phpcs.path %>',
         standard: phpStandard,
-        extensions: 'php,install,module,inc,profile',
         ignoreExitCode: ignoreError,
         report: 'checkstyle',
         reportFile: '<%= config.buildPaths.reports %>/phpcs.xml'
@@ -124,7 +131,9 @@ module.exports = function(grunt) {
 
   grunt.registerTask('validate', 'Validate the quality of custom code.', function(mode) {
     if (mode == 'newer') {
-      var newer = validate.map(function(item) { return 'newer:' + item; });
+      // Wrap each task configured for validate in the newer command.
+      // grunt-phplint already contains complex caching that does the same thing.
+      var newer = validate.map(function(item) { return item != 'phplint:all' ? 'newer:' + item : item; });
       grunt.task.run(newer);
     }
     else {

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -24,7 +24,7 @@ module.exports = function(grunt) {
       '!<%= config.srcPaths.drupal %>/**/*.features.*inc',
       '!<%= config.srcPaths.drupal %>/sites/**'
     ],
-    tasks: ['validate']
+    tasks: ['validate:newer']
   });
 
   grunt.config(['concurrent', 'watch-test'], {


### PR DESCRIPTION
When running `grunt build` or `grunt watch` to check code quality, we are only concerned with recent changes that may require action. `grunt analyze` is available to run comprehensive checks on the codebase and generate large reports on findings.

This branch converts `grunt validate` from a standard alias to one that can take a single sub-parameter, meaning we now have `grunt validate` for the behavior we know and love and `grunt validate:newer` as a task that prefaces the validation tasks with 'newer:' so they can be run more efficiently.

This alternate syntax has been swapped into watch and default configuration.

Achieving this required fixing grunt-phpcs support for grunt-newer. We are now using a fork off the completely refactored 0.4.0 version of grunt-phpcs. There were several bugs with this version:
  * no stdout on test failure
  * dropped support for ignoreExitCode
  * No support for newer.
We were already forked from the 0.3.0 version of grunt-phpcs to allow individual targets to override the main option configuration, so this changes very little except the details. All necessary changes to end the fork are already submitted as PRs.

Fixes #143 