### PR TITLE
Add a grunt serve task to official support drush runserver.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   - grunt --quiet --timer
   - echo "Fully built disk usage"; du -chs .
   - grunt drush:liteinstall --quiet
-  - grunt drush:runserver >/dev/null &
+  - grunt serve:test >/dev/null &
   - until curl -I -XGET -s $GDT_TEST_URL 2>/dev/null | egrep -q '^HTTP.*200'; do sleep 0.5; done
   - grunt test
   - sleep 1; while (ps aux | grep '[b]ehat' > /dev/null); do sleep 1; done

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -70,7 +70,7 @@ make file and add your custom code and configuration in the directories under
   with a setting change in Gruntconfig.json (see below).
 
 - Include any sites directories (like "default"), optionally with settings.php
-  or other files, and if needed a multi-site sites.php in **src/sites/**. (The 
+  or other files, and if needed a multi-site sites.php in **src/sites/**. (The
   contents of src/sites/ are copied into sites/.)
 
 - Include any static files that should be copied into the Drupal docroot on
@@ -292,9 +292,9 @@ This is an example of the settings for theme tasks:
 **themes**: Defines each custom Drupal theme and enables features, like Sass
 processing by Compass.
 
-**themes.\<theme\>.compass**: Enable compass preprocessing. Either `true` to 
-enable with default compass options, or a configuration object to be passed 
-directly to 
+**themes.\<theme\>.compass**: Enable compass preprocessing. Either `true` to
+enable with default compass options, or a configuration object to be passed
+directly to
 [grunt-contrib-compass](https://github.com/gruntjs/grunt-contrib-compass)
 for this theme.
 
@@ -348,7 +348,7 @@ installs the Drupal Coder's standard, the path of which is shown above.
 **phpcs.dir**: An array of globbing pattern where phpcs should search for files.
 This can be used to replace the defaults supplied by grunt-drupal-tasks.
 
-This example placed in the Gruntconfig.json file ignores directories named 
+This example placed in the Gruntconfig.json file ignores directories named
 "pattern-lab" and a "bower_components" in addition to the defaults that come with
 grunt-drupal-tasks:
 
@@ -403,6 +403,39 @@ this format, see: http://gruntjs.com/configuring-tasks#files
 **packages.projFiles**: An array of files or file patterns to include or exclude
 from the project directory when building a package. The above includes README
 files and files under bin/ in the project's package.
+
+### Serve Settings
+
+The Serve task allows you to run Drupal using PHP's built-in webserver. This
+facilitates quick demos and low-overhead development for projects with extremely
+simple infrastructure requirements. When using this task it will take over the
+terminal window.
+
+```
+{
+  "serve": {
+    "profile": 'project_profile_name',
+    "port": 9043,
+    "concurrent": [
+      "watch-theme"
+    ]
+
+}
+```
+
+**serve.profile**: The profile to use with the drush:liteinstall task. Defaults
+to `standard` and may be overridden with `--profile` when the command is run.
+WARNING: drush:liteinstall is an internal task and is likely to be deprecated in
+a future release.
+
+**serve.port**: The port number to bind for the webserver. Only one service may
+occupy a port on a machine, so a project-specific port may be worthwhile. Defaults
+to `8080`.
+
+**serve.concurrent**: An array of grunt tasks to be run concurrently to the server.
+When run with `serve:demo` or `serve:test` these tasks are not used. By default
+they include 'watch-test' and 'watch-theme'. If you use this configuration to
+add tasks be sure to include these as they will be suppressed by any configuration.
 
 ### Help Settings (Help API)
 

--- a/tasks/make.js
+++ b/tasks/make.js
@@ -33,23 +33,9 @@ module.exports = function(grunt) {
   make_args.push('--concurrency=' + limit);
   grunt.verbose.writeln('Configured for concurrency=' + limit);
 
-  grunt.config('drush', {
-    make: {
-      args: make_args,
-      options: _.extend({}, cmd)
-    },
-    liteinstall: {
-      args: ['site-install', '-y', 'standard', '--db-url=sqlite:/' + path.join(path.resolve(grunt.config('config.buildPaths.build')), 'drupal.sqlite')],
-      options: _.extend({
-        cwd: '<%= config.buildPaths.html %>'
-      }, cmd)
-    },
-    runserver: {
-      args: ['runserver', '8080'],
-      options: _.extend({
-        cwd: '<%= config.buildPaths.html %>'
-      }, cmd)
-    }
+  grunt.config(['drush', 'make'], {
+    args: make_args,
+    options: _.extend({}, cmd)
   });
 
   grunt.registerTask('drushmake', 'Prepare the build directory and run "drush make"', function() {

--- a/tasks/serve.js
+++ b/tasks/serve.js
@@ -1,0 +1,80 @@
+module.exports = function(grunt) {
+
+  /**
+   * Define tasks to quickly get Drupal running.
+   *
+   * grunt serve
+   *   Run Drupal via the PHP webserver and active watch tasks.
+   * grunt serve:demo
+   *   Run Drupal via the PHP webserver without running watch tasks.
+   * grunt serve:test
+   *   Run Drupal via the PHP webserver without running watch tasks or opening the browser.
+   */
+  grunt.loadNpmTasks('grunt-drush');
+  grunt.loadNpmTasks('grunt-newer');
+
+  var Help = require('../lib/help')(grunt),
+    Drupal = require('../lib/drupal')(grunt);
+
+  var path = require('path'),
+    _ = require('lodash');
+
+  // If no path is configured for Drush, fallback to the system path.
+  var cmd = {cmd: Drupal.drushPath()};
+
+  var profile = grunt.config('config.serve.profile') || 'standard';
+
+  grunt.config(['drush', 'liteinstall'], {
+    args: ['site-install', '-yv', profile, '--db-url=sqlite:/' + path.join(path.resolve(grunt.config('config.buildPaths.build')), 'drupal.sqlite')],
+    options: _.extend({
+      cwd: '<%= config.buildPaths.html %>'
+    }, cmd)
+  });
+
+  grunt.registerTask('serve', 'Run Drupal using the PHP built-in webserver. serve:demo to run without watch tasks and serve:test for grunt-drupal-tasks development.', function() {
+    grunt.config(['drush', 'serve'], {
+      args: ['runserver', ':' + (grunt.config('serve.port') || 8080)],
+      options: _.extend({
+        cwd: '<%= config.buildPaths.html %>'
+      }, cmd)
+    });
+
+    if (this.args[0] != 'test') {
+      // Unlike the test version, this one allows port overriding and opens the site in a new tab.
+      grunt.config('drush.serve.args', ['runserver', ':' + (grunt.config('serve.port') || 8080) + '/' ]);
+    }
+
+    if (this.args.length) {
+      grunt.task.run('drush:serve');
+    }
+    else {
+      grunt.loadNpmTasks('grunt-concurrent');
+
+      // Allow overriding the tasks run concurrently to the Drupal server.
+      var serveTasks = grunt.config('serve.concurrent');
+      if (!serveTasks) {
+        serveTasks = [ 'watch-test'];
+        if (grunt.task.exists('watch-theme')) {
+          serveTasks.push('watch-theme');
+        }
+      }
+      serveTasks.push('drush:serve');
+
+      grunt.config('concurrent.serve', {
+        tasks: serveTasks,
+        options: {
+          logConcurrentOutput: true
+        }
+      });
+
+      grunt.task.run('concurrent:serve');
+    }
+  });
+
+  Help.add([
+    {
+      task: 'serve',
+      group: 'Operations'
+    },
+  ]);
+};

--- a/tasks/serve.js
+++ b/tasks/serve.js
@@ -11,7 +11,6 @@ module.exports = function(grunt) {
    *   Run Drupal via the PHP webserver without running watch tasks or opening the browser.
    */
   grunt.loadNpmTasks('grunt-drush');
-  grunt.loadNpmTasks('grunt-newer');
 
   var Help = require('../lib/help')(grunt),
     Drupal = require('../lib/drupal')(grunt);
@@ -53,7 +52,7 @@ module.exports = function(grunt) {
       // Allow overriding the tasks run concurrently to the Drupal server.
       var serveTasks = grunt.config('serve.concurrent');
       if (!serveTasks) {
-        serveTasks = [ 'watch-test'];
+        serveTasks = ['watch-test'];
         if (grunt.task.exists('watch-theme')) {
           serveTasks.push('watch-theme');
         }

--- a/test/test.sh
+++ b/test/test.sh
@@ -8,7 +8,7 @@ run_tests () {
   cd test/working_copy/
   grunt --quiet
   grunt drush:liteinstall --quiet
-  grunt drush:runserver >/dev/null &
+  grunt serve:test >/dev/null &
   until curl -I -XGET -s $GDT_TEST_URL 2>/dev/null | egrep -q '^HTTP.*200'; do sleep 0.5; done
   grunt test
   sleep 1; while (ps aux | grep '[b]ehat' > /dev/null); do sleep 1; done


### PR DESCRIPTION
This PR defines a new task: grunt serve. It's got a couple variations built-in. See change for details.

Fixes #164, #150.

@arithmetric @mikeyp 