### PR TITLE
Decouple package generation from archive creation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Added theme scripts system to allow themes to own their [CLI destiny](https://github.com/phase2/grunt-drupal-tasks/blob/master/CONFIG.md#theme-scripts).
 - Added `phplint.dir` setting to Gruntconfig to allow customization of linting paths.
 - Added validate:newer and switched watch configuration top-level use it. Speed increase!
+- [New settings for `grunt package`](https://github.com/phase2/grunt-drupal-tasks/blob/master/CONFIG.md#package-settings)
+to make it easier to configure Acquia or Pantheon-compatible packages. Now
+produces a clean directory package for easy commit as-is to a release repository.
 
 ### Building GDT
 
@@ -18,6 +21,7 @@
 ### Breaking Changes
 
 - Renamed GRUNT_DRUPAL_QUIET to GDT_QUIET
+- `grunt package` no longer compresses by default. Use `grunt package:compress` to replicate existing behavior.
 
 ## v0.6.1 [2015/05/17]
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -420,6 +420,16 @@ exclude from PHP code syntax validation.
 
 ### Package Settings
 
+The `grunt package` task allows you to assemble and independently exported
+Drupal codebase. This is used to facilitate deployment of the minimal code
+needed to run Drupal in a formal environment such as Production.
+
+You can find the resulting package in `build/packages/package` by default as a
+standard directory, all symlinks from the grunt scaffolding dereferenced. If
+run with `grunt package:compress` it will also output `build/packages/package.tgz`
+as an easily stored archive. **Remember, this directory is wiped by `grunt clean`
+unless you configure your package directory to be outside the build directory.**
+
 This is an example of the settings for package tasks:
 
 ```
@@ -439,6 +449,13 @@ this format, see: http://gruntjs.com/configuring-tasks#files
 **packages.projFiles**: An array of files or file patterns to include or exclude
 from the project directory when building a package. The above includes README
 files and files under bin/ in the project's package.
+
+**packages.dest.docroot**: Specify where within the package directory the `srcFiles`
+should be placed. Defaults to the package root. For Acquia set this to
+'/docroot'.
+
+**packages.dest.devResources**: Specify where within the package directory the
+`projFiles` should be placed. Defaults to package root.
 
 ### Serve Settings
 

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -7,38 +7,36 @@ module.exports = function(grunt) {
    *   Copies all files from src/static to the build/html directory.
    */
   grunt.loadNpmTasks('grunt-contrib-copy');
-  grunt.config('copy', {
-    static: {
-      files: [
-        {
-          expand: true,
-          cwd: '<%= config.srcPaths.drupal %>/static',
-          src: ['**', '.**'],
-          dest: '<%= config.buildPaths.html %>',
-          dot: true
-        }
-      ]
-    },
-    tempbuild: {
-      files: [
-        {
-          expand: true,
-          cwd: '<%= config.buildPaths.temp %>',
-          src: ['**', '.**'],
-          dest: '<%= config.buildPaths.html %>',
-          dot: true
-        }
-      ]
-    },
-    defaults: {
-      files: [
-        {
-          expand: true,
-          cwd: '<%= config.buildPaths.html %>/sites/default',
-          src: ['default*'],
-          dest: '<%= config.srcPaths.drupal %>/sites/default'
-        }
-      ]
-    }
+  grunt.config('copy.static', {
+    files: [
+      {
+        expand: true,
+        cwd: '<%= config.srcPaths.drupal %>/static',
+        src: ['**', '.**'],
+        dest: '<%= config.buildPaths.html %>',
+        dot: true
+      }
+    ]
+  });
+  grunt.config('copy.tempbuild', {
+    files: [
+      {
+        expand: true,
+        cwd: '<%= config.buildPaths.temp %>',
+        src: ['**', '.**'],
+        dest: '<%= config.buildPaths.html %>',
+        dot: true
+      }
+    ]
+  });
+  grunt.config('copy.defaults', {
+    files: [
+      {
+        expand: true,
+        cwd: '<%= config.buildPaths.html %>/sites/default',
+        src: ['default*'],
+        dest: '<%= config.srcPaths.drupal %>/sites/default'
+      }
+    ]
   });
 };


### PR DESCRIPTION
The package command has been great, but it's tied very tightly to the production of tarball archives. Those archives are great for rsync deployment use cases, but are pretty limiting for other deployment mechanisms, such as those driven by git.

This change constructs the "code export" package as a normal directory and provides some more config to determine the top-level sub-directories so it can be adapted to different PaaS systems. Now your projects have a less prescriptive foundation for how deployment can be done.

Note that this does represent a B/C break for anyone using the existing package functionality to create archives. That functionality is preserved via `grunt package:compress`. We do our best to avoid breaks like this but we are still `< 1.0`.

This change should facilitate much more flexibility in how #24 is addressed, and allows generators to consider asking questions like "Where will your site be hosted?"