### PR TITLE
Run Behat with process env vars

### DIFF
--- a/tasks/behat.js
+++ b/tasks/behat.js
@@ -61,9 +61,9 @@ module.exports = function(grunt) {
               maxProcesses: 5,
               bin: 'vendor/bin/behat',
               debug: true,
-              env: {
+              env: _.extend({}, process.env, {
                 "BEHAT_PARAMS": "{\"extensions\": {\"Drupal\\\\DrupalExtension\": {\"drupal\": {\"drupal_root\": \"./" + config.buildPaths.html + "\"}}, \"Behat\\\\MinkExtension\": {\"base_url\": \"" + config.siteUrls[key] + "\", \"zombie\": {\"node_modules_path\": \"" + process.cwd() + "/node_modules/\"}}}}"
-              }
+              })
             }, options)
           }
         );


### PR DESCRIPTION
Ensure that Behat is run with the process's environment variables in addition to ones added by the Behat task.

@peterschuelke reported an issue where Behat failed to run through Grunt Drupal Tasks with the command: `/bin/sh -c vendor/bin/behat -c ./test/behat.yml --tags ~@wip ././test/features/dashboard.feature` but could be run manually with: `vendor/bin/behat -c ./test/behat.yml --tags ~@wip ././test/features/dashboard.feature`. Another environment had an issue running Behat where it reported php not being found.

After applying this patch, Behat was able to run through Grunt Drupal Tasks using the 'sh -c' shell wrapper.
