### PR TITLE
symlink libraries as part of scaffolding

### DIFF
--- a/tasks/scaffold.js
+++ b/tasks/scaffold.js
@@ -20,9 +20,7 @@ module.exports = function(grunt) {
       grunt.loadNpmTasks('grunt-contrib-symlink');
 
       grunt.config(['symlink', 'libraries'], {
-        expand: true,
-        cwd: '<%= config.srcPaths.drupal %>/libraries',
-        src: ['*'],
+        src: '<%= config.srcPaths.drupal %>/libraries',
         dest: drupal.libraryPath(),
       });
       grunt.config(['symlink', 'modules'], {

--- a/tasks/scaffold.js
+++ b/tasks/scaffold.js
@@ -20,7 +20,9 @@ module.exports = function(grunt) {
       grunt.loadNpmTasks('grunt-contrib-symlink');
 
       grunt.config(['symlink', 'libraries'], {
-        src: '<%= config.srcPaths.drupal %>/libraries',
+        expand: true,
+        cwd: '<%= config.srcPaths.drupal %>/libraries',
+        src: ['*'],
         dest: drupal.libraryPath(),
       });
       grunt.config(['symlink', 'modules'], {

--- a/tasks/scaffold.js
+++ b/tasks/scaffold.js
@@ -19,6 +19,10 @@ module.exports = function(grunt) {
 
       grunt.loadNpmTasks('grunt-contrib-symlink');
 
+      grunt.config(['symlink', 'libraries'], {
+        src: '<%= config.srcPaths.drupal %>/libraries',
+        dest: drupal.libraryPath(),
+      });
       grunt.config(['symlink', 'modules'], {
         src: '<%= config.srcPaths.drupal %>/modules',
         dest: path.join(drupal.modulePath(), 'custom')
@@ -46,6 +50,7 @@ module.exports = function(grunt) {
 
       grunt.task.run([
         'symlink:profiles',
+        'symlink:libraries',
         'symlink:modules',
         'symlink:themes',
         'copy:defaults',

--- a/test/build.js
+++ b/test/build.js
@@ -64,7 +64,7 @@ describe('grunt', function() {
     });
 
     // Ensure there is a symlink to src/libraries.
-    var librariesSrc = (drupalCore == '8') ? '../../../src/libraries' : '../../../../src/libraries',
+    var librariesSrc = (drupalCore == '8') ? '../../src/libraries' : '../../../../src/libraries',
       librariesDest = (drupalCore == '8') ? 'build/html/libraries' : 'build/html/sites/all/libraries';
     it('it should link the ' + librariesDest + ' directory', function(done) {
       fs.lstat(librariesDest, function (err, stats) {

--- a/test/build.js
+++ b/test/build.js
@@ -63,6 +63,25 @@ describe('grunt', function() {
       });
     });
 
+    // Ensure there is a symlink to src/libraries.
+    var librariesSrc = (drupalCore == '8') ? '../../../src/libraries' : '../../../../src/libraries',
+      librariesDest = (drupalCore == '8') ? 'build/html/libraries' : 'build/html/sites/all/libraries';
+    it('it should link the ' + librariesDest + ' directory', function(done) {
+      fs.lstat(librariesDest, function (err, stats) {
+        assert.ok(stats.isSymbolicLink());
+
+        if (stats.isSymbolicLink()) {
+          fs.readlink(librariesDest, function (err, linkString) {
+            assert.equal(linkString, librariesSrc);
+            done();
+          });
+        }
+        else {
+          done();
+        }
+      });
+    });
+
     // Ensure the build/html/sites/all/themes/custom/example_theme/stylesheets/screen.css
     // file exists, which should be created by compass.
     var sassDest = (drupalCore == '8') ? 'build/html/themes/custom/example_theme/stylesheets/screen.css' : 'build/html/sites/all/themes/custom/example_theme/stylesheets/screen.css';

--- a/test/build.js
+++ b/test/build.js
@@ -63,16 +63,18 @@ describe('grunt', function() {
       });
     });
 
-    // Ensure there is a symlink to src/libraries.
-    var librariesSrc = (drupalCore == '8') ? '../../src/libraries' : '../../../../src/libraries',
-      librariesDest = (drupalCore == '8') ? 'build/html/libraries' : 'build/html/sites/all/libraries';
-    it('it should link the ' + librariesDest + ' directory', function(done) {
-      fs.lstat(librariesDest, function (err, stats) {
+    // Ensure there is a symlink for libs in src/libraries.
+    var librariesSrc = (drupalCore == '8') ? '../../../src/libraries' : '../../../../../src/libraries',
+      exampleLibSrc = librariesSrc + '/example_lib',
+      librariesDest = (drupalCore == '8') ? 'build/html/libraries' : 'build/html/sites/all/libraries',
+      exampleLibDest = librariesDest + '/example_lib';
+    it('it should link libraries in the ' + librariesDest + ' directory', function(done) {
+      fs.lstat(exampleLibDest, function (err, stats) {
         assert.ok(stats.isSymbolicLink());
 
         if (stats.isSymbolicLink()) {
-          fs.readlink(librariesDest, function (err, linkString) {
-            assert.equal(linkString, librariesSrc);
+          fs.readlink(exampleLibDest, function (err, linkString) {
+            assert.equal(linkString, exampleLibSrc);
             done();
           });
         }

--- a/test/test_assets/src/libraries/example_lib/example.md
+++ b/test/test_assets/src/libraries/example_lib/example.md
@@ -1,0 +1,3 @@
+# Example library
+This is just a placeholder file to verify that grunt can symlink libraries into
+the appropriate place.

--- a/test/test_assets/src/libraries/example_lib/test.php
+++ b/test/test_assets/src/libraries/example_lib/test.php
@@ -1,5 +1,0 @@
-<?php
-/*
- * This is just a placeholder file to verify libraries can be symlinked into
- * the appropriate directory successfully.
- */

--- a/test/test_assets/src/libraries/example_lib/test.php
+++ b/test/test_assets/src/libraries/example_lib/test.php
@@ -1,0 +1,5 @@
+<?php
+/*
+ * This is just a placeholder file to verify libraries can be symlinked into
+ * the appropriate directory successfully.
+ */

--- a/test/test_assets_d8/src/libraries/example_lib/example.md
+++ b/test/test_assets_d8/src/libraries/example_lib/example.md
@@ -1,0 +1,3 @@
+# Example library
+This is just a placeholder file to verify that grunt can symlink libraries into
+the appropriate place.

--- a/test/test_assets_d8/src/libraries/example_lib/test.php
+++ b/test/test_assets_d8/src/libraries/example_lib/test.php
@@ -1,5 +1,0 @@
-<?php
-/*
- * This is just a placeholder file to verify libraries can be symlinked into
- * the appropriate directory successfully.
- */

--- a/test/test_assets_d8/src/libraries/example_lib/test.php
+++ b/test/test_assets_d8/src/libraries/example_lib/test.php
@@ -1,0 +1,5 @@
+<?php
+/*
+ * This is just a placeholder file to verify libraries can be symlinked into
+ * the appropriate directory successfully.
+ */


### PR DESCRIPTION
This adds symlinking of libraries in `src/libraries` as part of the default scaffold task.

You can either manually include whatever libraries your code requires, or if you're using something fancy like [Bower](http://bower.io/), just point that to the `src/libraries` directory in your `.bowerrc`.