### PR TITLE
Use Travis containers and test more PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 php:
   - 5.4
+sudo: false
 env:
   - GDT_DRUPAL_CORE="7" GDT_TEST_URL="http://127.0.0.1:8080/misc/drupal.js"
   - GDT_DRUPAL_CORE="8" GDT_TEST_URL="http://127.0.0.1:8080/core/misc/drupal.js"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: php
 php:
   - 5.4
+  - 5.5
+  - 5.6
+  - 7
 sudo: false
 env:
   - GDT_DRUPAL_CORE="7" GDT_TEST_URL="http://127.0.0.1:8080/misc/drupal.js"

--- a/test/test_assets_d8/src/project.make
+++ b/test/test_assets_d8/src/project.make
@@ -2,7 +2,7 @@ core = 8.x
 api = 2
 
 ; Drupal Core
-projects[drupal][version] = "8.0.0-beta9"
+projects[drupal][version] = "8.0.0-beta12"
 
 ; =====================================
 ; Contrib Modules


### PR DESCRIPTION
Switch to using Travis's container-based infrastructure, and add more PHP versions to the config.
