### PR TITLE
Display error thrown by drush.

### DIFF
--- a/tasks/scaffold.js
+++ b/tasks/scaffold.js
@@ -13,7 +13,7 @@ module.exports = function(grunt) {
       drupal = require('../lib/drupal')(grunt);
     drupal.loadDrushStatus(function (err) {
       if (err) {
-        grunt.fail.fatal('Cannot load Drush status for built Drupal docroot.');
+        grunt.fail.fatal('Cannot load Drush status for built Drupal docroot.\n\n' + err);
         return done();
       }
 


### PR DESCRIPTION
If drush throws a fatal error during `grunt scaffold` it is currently hidden:

```
Running "scaffold" task
drush status failed with code 255
Detected Drupal 0 codebase.
Fatal error: Cannot load Drush status for built Drupal docroot.
```

with this change, the error is displayed:
```
Running "scaffold" task
drush status failed with code 255
Detected Drupal 0 codebase.
Fatal error: Cannot load Drush status for built Drupal docroot.

Error: Drush command terminated abnormally due to an unrecoverable error.                                                                                                        [error]
Error: Cannot redeclare GuzzleHttp\Psr7\str() (previously declared in /Users/jhedstrom/work/p2/drupal-ci-test/vendor/guzzlehttp/psr7/src/functions.php:17) in
/Users/jhedstrom/work/p2/drupal-ci-test/build/html/core/vendor/guzzlehttp/psr7/src/functions.php, line 39
```