### PR TITLE
Do not test Drupal 8 on PHP 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ sudo: false
 env:
   - GDT_DRUPAL_CORE="7" GDT_TEST_URL="http://127.0.0.1:8080/misc/drupal.js"
   - GDT_DRUPAL_CORE="8" GDT_TEST_URL="http://127.0.0.1:8080/core/misc/drupal.js"
+matrix:
+  exclude:
+    - php: 5.4
+      env: GDT_DRUPAL_CORE="8" GDT_TEST_URL="http://127.0.0.1:8080/core/misc/drupal.js"
 before_install:
   - composer self-update
   - echo "sendmail_path='true'" >> `php --ini | grep "Loaded Configuration" | awk '{print $4}'`


### PR DESCRIPTION
The PHP 5.4/ Drupal 8 build is failing over in #187 (not sure why it isn't failing without that). This excludes building Drupal 8 on the PHP 5.4 environment.