### PR TITLE
Prevents phpcs tasks being added if no files

### DIFF
--- a/tasks/quality.js
+++ b/tasks/quality.js
@@ -46,8 +46,8 @@ module.exports = function(grunt) {
 
   if (grunt.config.get('config.phpcs') != undefined) {
     var phpcs = grunt.config.get('config.phpcs.dir') || [
-      '<%= config.srcPaths.drupal %>/**/*.css'
-    ].concat(defaultPatterns);
+        '<%= config.srcPaths.drupal %>/**/*.css'
+      ].concat(defaultPatterns);
 
     var phpStandard = grunt.config('config.phpcs.standard')
       || 'vendor/drupal/coder/coder_sniffer/Drupal';
@@ -56,52 +56,56 @@ module.exports = function(grunt) {
     var ignoreError = grunt.config('config.validate.ignoreError') || grunt.config('config.phpcs.ignoreExitCode');
     ignoreError = ignoreError === undefined ? false : ignoreError;
 
-    grunt.config('phpcs', {
-      analyze: {
-        src: phpcs
-      },
-      drupal: {
-        src: phpcs
-      },
-      validate: {
-        src: phpcs,
-        options: {
-          report: grunt.config.get('config.phpcs.validateReport') || 'full',
-          reportFile: false
-        }
-      },
-      full: {
-        src: phpcs,
-        options: {
-          report: 'full',
-          reportFile: false
-        }
-      },
-      summary: {
-        src: phpcs,
-        options: {
-          report: 'summary',
-          reportFile: false
-        }
-      },
-      gitblame: {
-        src: phpcs,
-        options: {
-          report: 'gitblame',
-          reportFile: false
-        }
-      },
-      options: {
-        bin: '<%= config.phpcs.path %>',
-        standard: phpStandard,
-        ignoreExitCode: ignoreError,
-        report: 'checkstyle',
-        reportFile: '<%= config.buildPaths.reports %>/phpcs.xml'
-      }
-    });
+    if (grunt.file.expand(phpcs).length !== 0) {
 
-    validate.push('phpcs:validate');
-    analyze.push('phpcs:analyze');
+      grunt.config('phpcs', {
+        analyze: {
+          src: phpcs
+        },
+        drupal: {
+          src: phpcs
+        },
+        validate: {
+          src: phpcs,
+          options: {
+            report: grunt.config.get('config.phpcs.validateReport') || 'full',
+            reportFile: false
+          }
+        },
+        full: {
+          src: phpcs,
+          options: {
+            report: 'full',
+            reportFile: false
+          }
+        },
+        summary: {
+          src: phpcs,
+          options: {
+            report: 'summary',
+            reportFile: false
+          }
+        },
+        gitblame: {
+          src: phpcs,
+          options: {
+            report: 'gitblame',
+            reportFile: false
+          }
+        },
+        options: {
+          bin: '<%= config.phpcs.path %>',
+          standard: phpStandard,
+          ignoreExitCode: ignoreError,
+          report: 'checkstyle',
+          reportFile: '<%= config.buildPaths.reports %>/phpcs.xml'
+        }
+      });
+
+      validate.push('phpcs:validate');
+      analyze.push('phpcs:analyze');
+    }
+
   }
 
   if (grunt.config.get('config.phpmd') != undefined) {


### PR DESCRIPTION
This just expands the file globbing done on `phpcs` and sees if there's not 0 files before setting the config and adding it to the validate and analyze task. The diff is best [viewed with no whitespace](https://github.com/phase2/grunt-drupal-tasks/pull/192/files?w=0) as it's really just wrapping the code in `if (grunt.file.expand(phpcs).length !== 0) {}`. This should resolve #174