### PR TITLE
adding ability to skip `grunt:validate` step to default task

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ These flags are not yet documented as part of the `grunt help` command.
 * `--notify`: Request a desktop notification despite timing or environment settings.
 * `--timer`: Output execution time profile at the end of the task run.
 * `--concurrency`: Override the dynamic concurrency by Drush Make.
+* `--no-validate`: Skip `grunt:validate` in the default `grunt` task.
 
 ### Environment Options
 

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -36,6 +36,7 @@ module.exports = function(grunt) {
   if (grunt.task.exists('bundle-install')) {
     tasksDefault.push('bundle-install');
   }
+  // If the "--no-validate" option is given, skip adding "validate" to task array.
   if (!grunt.option('no-validate')) {
     tasksDefault.push('validate');
   }

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -28,17 +28,19 @@ module.exports = function(grunt) {
   grunt.loadTasks(__dirname + '/tasks');
 
   // Define the default task to fully build and configure the project.
-  var tasksDefault = [
-    'validate',
-    'newer:drushmake:default',
-    'scaffold'
-  ];
+  var tasksDefault = [];
+  
   if (grunt.config.get(['composer', 'install'])) {
-    tasksDefault.unshift('composer:install');
+    tasksDefault.push('composer:install');
   }
   if (grunt.task.exists('bundle-install')) {
-    tasksDefault.unshift('bundle-install');
+    tasksDefault.push('bundle-install');
   }
+  if (!grunt.option('no-validate')) {
+    tasksDefault.push('validate');
+  }
+  tasksDefault.push('newer:drushmake:default');
+  tasksDefault.push('scaffold');
   if (grunt.task.exists('compile-theme')) {
     tasksDefault.push('compile-theme');
   }


### PR DESCRIPTION
Run `grunt --no-validate` to skip `grunt:validate` in default `grunt` task. Helpful for troubleshooting as it skips the step that takes the longest or can potentially fail the whole build. 