### PR TITLE
Initial swing and proof of concept for acquia packaging.

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -451,6 +451,8 @@ The `grunt package` task allows you to assemble and independently exported
 Drupal codebase. This is used to facilitate deployment of the minimal code
 needed to run Drupal in a formal environment such as Production.
 
+#### Default Packaging
+
 You can find the resulting package in `build/packages/package` by default as a
 standard directory, all symlinks from the grunt scaffolding dereferenced. If
 run with `grunt package:compress` it will also output `build/packages/package.tgz`
@@ -468,6 +470,8 @@ This is an example of the settings for package tasks:
 }
 ```
 
+##### Packaging Customization
+
 **packages.srcFiles**: An array of files or file patterns to include or exclude
 from the build output when building a package. The above excludes files within
 any sites/*/files directory, and Drupal's xmlrpc.php and PHP Filter. For more on
@@ -483,6 +487,38 @@ should be placed. Defaults to the package root. For Acquia set this to
 
 **packages.dest.devResources**: Specify where within the package directory the
 `projFiles` should be placed. Defaults to package root.
+
+Also, the `package` command takes a `--target` parameter. Usage such as 
+
+    grunt package --target=MY_TARGET
+
+will yeild a `MY_TARGET` directory in the `packages` directory. This also works for the `package:compress` option.
+
+##### Packaging for Acquia
+
+Support for Acquia packaging is baked into the `package` command. You'll just need to place a few directories in the right place, and make a few additions to your additions to your local `Gruntconfig.json` file. First be sure your `hooks` and `bin` directories are placed at the repository root. 
+
+Also, you'll need to set **packages.dest.docroot** as mentioned above to '/docroot':
+
+    ...
+    "packages": {
+      "srcFiles": ["!sites/*/files/**", "!xmlrpc.php", "!modules/php/*"],
+      "projFiles": ["README*", "bin/**", "hooks/**"],
+      "dest": {
+        "docroot": "/docroot"
+      }
+    }
+    ...
+
+Then, you can either pass in a target name (`--target=TARGET_NAME`, for example) when you use the `package` command, or you can add spec in your local configuration:
+
+    ...
+    "buildPaths": {
+      "packages": "build/packages",
+      "packageTarget": "TARGET_NAME"
+    }
+    ...
+
 
 ### Serve Settings
 

--- a/example/Gruntconfig.json
+++ b/example/Gruntconfig.json
@@ -1,6 +1,6 @@
 {
   "srcPaths": {
-    "make": "src/*.make",
+    "make": "src/project.make",
     "drupal": "src"
   },
   "domain": "project.vm",
@@ -9,7 +9,7 @@
   },
   "packages": {
     "srcFiles": ["!sites/*/files/**", "!xmlrpc.php", "!modules/php/*"],
-    "projFiles": ["README*", "bin/**", "hooks/**"]
+    "projFiles": ["README*", "bin/**", "hooks/**", "src/*.make"]
   },
   "phpcs": {
     "path": "vendor/bin/phpcs"

--- a/example/Gruntconfig.json
+++ b/example/Gruntconfig.json
@@ -5,8 +5,20 @@
   },
   "domain": "project.vm",
   "packages": {
-    "srcFiles": ["!sites/*/files/**", "!xmlrpc.php", "!modules/php/*"],
-    "projFiles": ["README*", "bin/**"]
+    "default": {
+      "srcFiles": ["!sites/*/files/**", "!xmlrpc.php", "!modules/php/*"],
+      "projFiles": ["README*", "bin/**"]
+    },
+    "acquia": {
+      "srcFiles": ["**", ".**", "!sites/default/**", "!sites/*/files/**", "!??/**", "!sites/all/modules/dev/**", "!sites/*/settings.php", "!sites/*/settings.db.inc", "!sites/*/settings.local.inc", "!.htaccess", "!.gitignore", "!.gitkeep"],
+      "sharedFiles": ["**", "!files/**", "!default.settings.php", "settings.php", "!settings.local.inc"],
+      "projFiles": ["README*", "bin/**"],
+      "root": "build/packages/acquia",
+      "paths": {
+        "docroot": "build/packages/acquia/docroot",
+        "shared": "build/packages/acquia/shared"
+      }
+    }
   },
   "phpcs": {
     "path": "vendor/bin/phpcs"
@@ -22,3 +34,4 @@
   },
   "eslint": true
 }
+

--- a/example/Gruntconfig.json
+++ b/example/Gruntconfig.json
@@ -1,24 +1,19 @@
 {
   "srcPaths": {
     "make": "src/project.make",
-    "drupal": "src"
+    "drupal": "src",
+    "devroot": "devroot"
   },
   "domain": "project.vm",
-  "packages": {
-    "default": {
-      "srcFiles": ["!sites/*/files/**", "!xmlrpc.php", "!modules/php/*"],
-      "projFiles": ["README*", "bin/**"]
-    },
-    "acquia": {
-      "srcFiles": ["**", ".**", "!sites/default/**", "!sites/*/files/**", "!??/**", "!sites/all/modules/dev/**", "!sites/*/settings.php", "!sites/*/settings.db.inc", "!sites/*/settings.local.inc", "!.htaccess", "!.gitignore", "!.gitkeep"],
-      "sharedFiles": ["**", "!files/**", "!default.settings.php", "settings.php", "!settings.local.inc"],
-      "projFiles": ["README*", "bin/**"],
-      "root": "build/packages/acquia",
-      "paths": {
-        "docroot": "build/packages/acquia/docroot",
-        "shared": "build/packages/acquia/shared"
-      }
+  "buildPaths": {
+    "package": {
+      "default": "build/packages/package",
+      "acquia": "build/packages/acquia"
     }
+  },
+  "packages": {
+    "srcFiles": ["!sites/*/files/**", "!xmlrpc.php", "!modules/php/*"],
+    "projFiles": ["README*", "bin/**"]
   },
   "phpcs": {
     "path": "vendor/bin/phpcs"
@@ -34,4 +29,3 @@
   },
   "eslint": true
 }
-

--- a/example/Gruntconfig.json
+++ b/example/Gruntconfig.json
@@ -1,19 +1,15 @@
 {
   "srcPaths": {
-    "make": "src/project.make",
-    "drupal": "src",
-    "devroot": "devroot"
+    "make": "src/*.make",
+    "drupal": "src"
   },
   "domain": "project.vm",
   "buildPaths": {
-    "package": {
-      "default": "build/packages/package",
-      "acquia": "build/packages/acquia"
-    }
+    "packages": "build/packages"
   },
   "packages": {
     "srcFiles": ["!sites/*/files/**", "!xmlrpc.php", "!modules/php/*"],
-    "projFiles": ["README*", "bin/**"]
+    "projFiles": ["README*", "bin/**", "hooks/**"]
   },
   "phpcs": {
     "path": "vendor/bin/phpcs"

--- a/tasks/clean.js
+++ b/tasks/clean.js
@@ -21,6 +21,10 @@ module.exports = function(grunt) {
     ],
     temp: [
       '<%= config.buildPaths.temp %>'
+    ],
+    packages: [
+      '<%= config.buildPaths.package.default %>',
+      '<%= config.buildPaths.package.acquia %>'
     ]
   });
 

--- a/tasks/clean.js
+++ b/tasks/clean.js
@@ -23,8 +23,7 @@ module.exports = function(grunt) {
       '<%= config.buildPaths.temp %>'
     ],
     packages: [
-      '<%= config.buildPaths.package.default %>',
-      '<%= config.buildPaths.package.acquia %>'
+      '<%= config.buildPaths.packages %>/**'
     ]
   });
 

--- a/tasks/package.js
+++ b/tasks/package.js
@@ -40,12 +40,6 @@ module.exports = function(grunt) {
           src: projFiles,
           dest: destPath + (grunt.config.get('config.packages.dest.devResources') || ''),
           dot: true
-        },
-        {
-          expand: true,
-          src: grunt.config.get('config.srcPaths.make'),
-          dest: destPath + (grunt.config.get('config.packages.dest.devResources') || ''),
-          flatten: true
         }
       ],
       options: {

--- a/tasks/package.js
+++ b/tasks/package.js
@@ -37,10 +37,15 @@ module.exports = function(grunt) {
         },
         {
           expand: true,
-          cwd: cwd,
           src: projFiles,
           dest: destPath + (grunt.config.get('config.packages.dest.devResources') || ''),
           dot: true
+        },
+        {
+          expand: true,
+          src: grunt.config.get('config.srcPaths.make'),
+          dest: destPath + (grunt.config.get('config.packages.dest.devResources') || ''),
+          flatten: true
         }
       ],
       options: {

--- a/tasks/package.js
+++ b/tasks/package.js
@@ -13,21 +13,18 @@ module.exports = function(grunt) {
     var path = require('path');
     grunt.loadNpmTasks('grunt-contrib-copy');
 
-    var config = grunt.config.get('config.packages.default'),
+    var config = grunt.config.get('config.packages'),
       srcFiles = ['**', '!**/.gitkeep'].concat((config && config.srcFiles && config.srcFiles.length) ? config.srcFiles : '**'),
       projFiles = (config && config.projFiles && config.projFiles.length) ? config.projFiles : [];
 
-    var packageTarget = (grunt.config.get('config.buildPaths.packageTarget') || 'default');
-    var destPath = grunt.config.get('config.buildPaths.package.' + packageTarget);
-    var tasks = []
-
-    // If we are working with an acquia package, all repo-root files other than /docroot
-    // will be in /devroot. "Project" files should come from there.
-    var cwd = '';
-    if (packageTarget == 'acquia') {
-      cwd = '<%= config.srcPaths.devroot %>';
-      projFiles += ['**'];
+    // Look for a package target spec, build destination path.
+    var packageTarget = grunt.option('target') || process.env.GRUNT_PACKAGE_TARGET;
+    if (!packageTarget) {
+      packageTarget = (grunt.config.get('config.buildPaths.packageTarget') || 'package');
     }
+
+    var destPath = grunt.config.get('config.buildPaths.packages') + '/' + packageTarget;
+    var tasks = [];
 
     grunt.config('copy.package', {
       files: [

--- a/tasks/package.js
+++ b/tasks/package.js
@@ -17,106 +17,42 @@ module.exports = function(grunt) {
       srcFiles = ['**', '!**/.gitkeep'].concat((config && config.srcFiles && config.srcFiles.length) ? config.srcFiles : '**'),
       projFiles = (config && config.projFiles && config.projFiles.length) ? config.projFiles : [];
 
-    var destPath = grunt.config.get('config.buildPaths.package') + '/package';
+    var packageTarget = (grunt.config.get('config.buildPaths.packageTarget') || 'default');
+    var destPath = grunt.config.get('config.buildPaths.package.' + packageTarget);
     var tasks = []
 
-    // Figure out if we are building a vendor-specific package.
-    var buildTarget = grunt.option('target') || process.env.GRUNT_PACKAGE_TARGET;
-    if (buildTarget && isValidTarget(buildTarget)) {
-      grunt.config('config.buildTarget', grunt.option('target'))
+    // If we are working with an acquia package, all repo-root files other than /docroot
+    // will be in /devroot. "Project" files should come from there.
+    var cwd = '';
+    if (packageTarget == 'acquia') {
+      cwd = '<%= config.srcPaths.devroot %>';
+      projFiles += ['**'];
     }
-    else {
-      grunt.config('config.buildTarget', 'default');
-    }
-    grunt.log.writeln('Building package for ' + grunt.config.get('config.buildTarget'));
 
-    var validTarget = grunt.config.get('config.buildTarget');
-
-    // Build the specified vendor target, or the default.
-    switch (validTarget) {
-      case 'acquia':
-        /**
-         * Acquia release build tasks.
-         */
-        grunt.config.merge({
-          copy: { 'acquia_docroot': {
-            files: [
-              {
-                expand: true,
-                cwd: '<%= config.buildPaths.html %>',
-                src: '<%= config.packages.acquia.srcFiles %>',
-                dest: '<%= config.packages.acquia.paths.docroot %>'
-              }
-            ]
-          }}
-        });
-        grunt.config.merge({
-          copy: { 'acquia_shared': {
-            files: [
-              {
-                expand: true,
-                cwd: '<%= config.buildPaths.html %>/sites/default',
-                src: '<%= config.packages.acquia.sharedFiles %>',
-                dest: '<%= config.packages.acquia.paths.shared %>'
-              }
-            ]
-          }}
-        });
-
-        /**
-         * Acquia clean tasks.
-         */
-        grunt.config.merge({
-          clean: {
-            'acquia_docroot': '<%= config.packages.acquia.paths.docroot %>',
-            'acquia_shared': '<%= config.packages.acquia.paths.shared %>'
-          }
-        });
-
-        /**
-         * Symlink shared files (settings, etc) that is not part of docroot.
-         */
-        grunt.loadNpmTasks('grunt-contrib-symlink');
-        grunt.config(['symlink', 'shared'], {
+    grunt.config('copy.package', {
+      files: [
+        {
           expand: true,
-          cwd: '<%= config.packages.acquia.paths.shared %>',
-          src: ['*'],
-          dest: '<%= config.packages.acquia.paths.docroot %>/sites/default/'
-        });
+          cwd: '<%= config.buildPaths.html %>',
+          src: srcFiles,
+          dest: destPath + (grunt.config.get('config.packages.dest.docroot') || ''),
+          dot: true
+        },
+        {
+          expand: true,
+          cwd: cwd,
+          src: projFiles,
+          dest: destPath + (grunt.config.get('config.packages.dest.devResources') || ''),
+          dot: true
+        }
+      ],
+      options: {
+        gruntLogHeader: false
+      }
+    });
 
-        tasks.push('clean:acquia_docroot');
-        tasks.push('clean:acquia_shared');
-        tasks.push('copy:acquia_docroot');
-        tasks.push('copy:acquia_shared');
-        tasks.push('symlink:shared');
-
-        break;
-
-      default:
-        grunt.config('copy.package', {
-          files: [
-            {
-              expand: true,
-              cwd: '<%= config.buildPaths.html %>',
-              src: srcFiles,
-              dest: destPath + (grunt.config.get('config.packages.dest.docroot') || ''),
-              dot: true
-            },
-            {
-              expand: true,
-              src: projFiles,
-              dest: destPath + (grunt.config.get('config.packages.dest.devResources') || ''),
-              dot: true
-            }
-          ],
-          options: {
-            gruntLogHeader: false
-          }
-        });
-
-        tasks.push('copy:package');
-
-    }
+    tasks.push('clean:packages');
+    tasks.push('copy:package');
 
     if (this.args[0] && this.args[0] == 'compress') {
       grunt.loadNpmTasks('grunt-contrib-compress');
@@ -127,11 +63,11 @@ module.exports = function(grunt) {
           gruntLogHeader: false
         },
         files: [
-          {
+          { 
             expand: true,
             dot: true,
-            cwd: grunt.config.get('config.buildPaths.package'),
-            src: 'package/**',
+            cwd: grunt.config.get('config.buildPaths.package.' + packageTarget),
+            src: ['**'],
           }
         ]
       });
@@ -146,15 +82,5 @@ module.exports = function(grunt) {
     task: 'package',
     group: 'Operations'
   });
-
-  function isValidTarget(target) {
-    if (target.length) {
-      var validTargets = ['acquia'];
-      return (validTargets.indexOf(target) > -1);
-    }
-    else {
-      return false;
-    }
-  }
 
 };

--- a/tasks/package.js
+++ b/tasks/package.js
@@ -68,7 +68,7 @@ module.exports = function(grunt) {
           { 
             expand: true,
             dot: true,
-            cwd: grunt.config.get('config.buildPaths.package.' + packageTarget),
+            cwd: grunt.config.get('config.buildPaths.packages') + '/' + packageTarget,
             src: ['**'],
           }
         ]

--- a/tasks/package.js
+++ b/tasks/package.js
@@ -13,35 +13,110 @@ module.exports = function(grunt) {
     var path = require('path');
     grunt.loadNpmTasks('grunt-contrib-copy');
 
-    var config = grunt.config.get('config.packages'),
+    var config = grunt.config.get('config.packages.default'),
       srcFiles = ['**', '!**/.gitkeep'].concat((config && config.srcFiles && config.srcFiles.length) ? config.srcFiles : '**'),
       projFiles = (config && config.projFiles && config.projFiles.length) ? config.projFiles : [];
 
     var destPath = grunt.config.get('config.buildPaths.package') + '/package';
     var tasks = []
 
-    grunt.config('copy.package', {
-      files: [
-        {
-          expand: true,
-          cwd: '<%= config.buildPaths.html %>',
-          src: srcFiles,
-          dest: destPath + (grunt.config.get('config.packages.dest.docroot') || ''),
-          dot: true
-        },
-        {
-          expand: true,
-          src: projFiles,
-          dest: destPath + (grunt.config.get('config.packages.dest.devResources') || ''),
-          dot: true
-        }
-      ],
-      options: {
-        gruntLogHeader: false
-      }
-    });
+    // Figure out if we are building a vendor-specific package.
+    var buildTarget = grunt.option('target') || process.env.GRUNT_PACKAGE_TARGET;
+    if (buildTarget && isValidTarget(buildTarget)) {
+      grunt.config('config.buildTarget', grunt.option('target'))
+    }
+    else {
+      grunt.config('config.buildTarget', 'default');
+    }
+    grunt.log.writeln('Building package for ' + grunt.config.get('config.buildTarget'));
 
-    tasks.push('copy:package');
+    var validTarget = grunt.config.get('config.buildTarget');
+
+    // Build the specified vendor target, or the default.
+    switch (validTarget) {
+      case 'acquia':
+        /**
+         * Acquia release build tasks.
+         */
+        grunt.config.merge({
+          copy: { 'acquia_docroot': {
+            files: [
+              {
+                expand: true,
+                cwd: '<%= config.buildPaths.html %>',
+                src: '<%= config.packages.acquia.srcFiles %>',
+                dest: '<%= config.packages.acquia.paths.docroot %>'
+              }
+            ]
+          }}
+        });
+        grunt.config.merge({
+          copy: { 'acquia_shared': {
+            files: [
+              {
+                expand: true,
+                cwd: '<%= config.buildPaths.html %>/sites/default',
+                src: '<%= config.packages.acquia.sharedFiles %>',
+                dest: '<%= config.packages.acquia.paths.shared %>'
+              }
+            ]
+          }}
+        });
+
+        /**
+         * Acquia clean tasks.
+         */
+        grunt.config.merge({
+          clean: {
+            'acquia_docroot': '<%= config.packages.acquia.paths.docroot %>',
+            'acquia_shared': '<%= config.packages.acquia.paths.shared %>'
+          }
+        });
+
+        /**
+         * Symlink shared files (settings, etc) that is not part of docroot.
+         */
+        grunt.loadNpmTasks('grunt-contrib-symlink');
+        grunt.config(['symlink', 'shared'], {
+          expand: true,
+          cwd: '<%= config.packages.acquia.paths.shared %>',
+          src: ['*'],
+          dest: '<%= config.packages.acquia.paths.docroot %>/sites/default/'
+        });
+
+        tasks.push('clean:acquia_docroot');
+        tasks.push('clean:acquia_shared');
+        tasks.push('copy:acquia_docroot');
+        tasks.push('copy:acquia_shared');
+        tasks.push('symlink:shared');
+
+        break;
+
+      default:
+        grunt.config('copy.package', {
+          files: [
+            {
+              expand: true,
+              cwd: '<%= config.buildPaths.html %>',
+              src: srcFiles,
+              dest: destPath + (grunt.config.get('config.packages.dest.docroot') || ''),
+              dot: true
+            },
+            {
+              expand: true,
+              src: projFiles,
+              dest: destPath + (grunt.config.get('config.packages.dest.devResources') || ''),
+              dot: true
+            }
+          ],
+          options: {
+            gruntLogHeader: false
+          }
+        });
+
+        tasks.push('copy:package');
+
+    }
 
     if (this.args[0] && this.args[0] == 'compress') {
       grunt.loadNpmTasks('grunt-contrib-compress');
@@ -71,4 +146,15 @@ module.exports = function(grunt) {
     task: 'package',
     group: 'Operations'
   });
+
+  function isValidTarget(target) {
+    if (target.length) {
+      var validTargets = ['acquia'];
+      return (validTargets.indexOf(target) > -1);
+    }
+    else {
+      return false;
+    }
+  }
+
 };


### PR DESCRIPTION
This is a work in progress. Issuing a PR for visibility and review. At this point i'm wondering if this is the right architecture for release packaging. Most importantly, packaging does a little disassembly of the `html` build (as the original `package` command does), and splits it out into subdirectories. This structure is inspired by an older clinet project that is directly deployed to Acquia as-is.

Another question here is how the packaging should be invoked. Right now it's

```bash
grunt package --target=acquia
```

I thought it might make sense to have the `:compress` modifier work regardless of vendor target, but no work towards that was done. Compressing still works with the default command, i.e. no `--target` specifier.

The code style definitely needs work, as this is really POC-ey. Further, no work towards the recieving repository has been considered. The idea there is that should be configured by the derivative project.

Finally, some thought might want to be thrown at how this will work with gadget. Does it make any sense to move the logic in its entirety to derivative project setup, rather than accounting for vendors on this side?
