### PR TITLE
Lacking an index.php, do not run drushmake with newer.

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -29,10 +29,25 @@ module.exports = function(grunt) {
 
   // Define the default task to fully build and configure the project.
   var tasksDefault = [
-    'validate',
-    'newer:drushmake:default',
-    'scaffold'
+    'validate'
   ];
+
+  // If build/html exists, but is empty, skip the newer check.
+  // This facilitates situations where the build/html is generated as a mounted
+  // directory point with a newer timestamp than the Drush Makefiles.
+  //
+  // We do not use the grunt-newer .cache with drushmake so skipping newer for
+  // any one run does not impact later behavior.
+  if (grunt.file.exists(grunt.config.get('config.buildPaths.html') + '/index.php')) {
+    tasksDefault.push('newer:drushmake:default');
+  }
+  else {
+    tasksDefault.push('drushmake:default');
+  }
+
+  // Wire up the generated docroot to our custom code.
+  tasksDefault.push('scaffold');
+
   if (grunt.config.get(['composer', 'install'])) {
     tasksDefault.unshift('composer:install');
   }


### PR DESCRIPTION
In working in a local mounted filesystem context the newer:drushmake task in the default build was typically failing to detect the makefiles as actionable. On investigation, this appears to be because a mounted directory to build/html is setting the timestamp for an otherwise empty directory.

grunt-newer does not have an option to override the destination path to effectively hack the timestamp for comparison, so I've instead tweaked our default task to conditionally exclude the `newer:` flag if index.php is missing.

Not only will this avoid errors for the specified mounted directory problem, it will also allow the default build process to proceed if someone manually removes build/html contents without deleting the build/html directory itself.

cc @arithmetric 