### PR TITLE
Fix test failures on PHP 5.5+ for Drupal 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,5 @@ script:
   - grunt test
   - sleep 1; while (ps aux | grep '[b]ehat' > /dev/null); do sleep 1; done
   - for pid in `ps aux | grep drush | grep runserver | awk '{print $2}'`; do echo "Stopping drush pid $pid"; kill -SIGINT $pid; done;
-  - mocha node_modules/grunt-drupal-tasks/test/build.js
+  - mocha --timeout 10000 node_modules/grunt-drupal-tasks/test/build.js
   - mocha node_modules/grunt-drupal-tasks/test/library.js

--- a/test/test.sh
+++ b/test/test.sh
@@ -14,7 +14,7 @@ run_tests () {
   sleep 1; while (ps aux | grep '[b]ehat' > /dev/null); do sleep 1; done
   for pid in `ps aux | grep drush | grep runserver | awk '{print $2}'`; do echo "Stopping drush pid $pid"; kill -SIGINT $pid; done;
   # end-to-end tests
-  mocha node_modules/grunt-drupal-tasks/test/build.js
+  mocha --timeout 10000 node_modules/grunt-drupal-tasks/test/build.js
   # unit tests
   mocha node_modules/grunt-drupal-tasks/test/library.js
 }


### PR DESCRIPTION
Did not look into why these combinations are taking more time, but the mocha default timeout of 2 seconds is being fairly routinely reached. I have bumped the limit to 10 seconds here and observed tests passing.

@arithmetric @jhedstrom 