### PR TITLE
Fixing `grunt install` via dbload

### DIFF
--- a/tasks/install.js
+++ b/tasks/install.js
@@ -41,6 +41,12 @@ module.exports = function(grunt) {
       cwd: '<%= config.buildPaths.html %>'
     }, cmd)
   });
+  grunt.config(['drush', 'updb'], {
+    args: ['updatedb', '-y' ],
+    options: _.extend({
+      cwd: '<%= config.buildPaths.html %>'
+    }, cmd)
+  });
   grunt.config(['shell', 'loaddb'], {
     command: 'gzip -dc <%= config.project.db %> | <%= config.project.dbConnection %>'
   });

--- a/tasks/install.js
+++ b/tasks/install.js
@@ -50,7 +50,7 @@ module.exports = function(grunt) {
     var done = this.async();
 
     // Check for a database file first.
-    var dbPath = grunt.config('config.install.db');
+    var dbPath = grunt.config('config.project.db');
     if (dbPath && grunt.file.exists(dbPath)) {
       Drupal.loadDatabaseConnection(function(error) {
         if (error) {


### PR DESCRIPTION
The new grunt install functionality had two problems.

1. The code was using a blend of `config.project.db` and `config.install.db`, which led to some mysterious hangs. I have standardized on the documented `config.project.db`.
2. `drush:updb` was not defined. I have remedied that.

With these changes, grunt install from an existing database export seems to work.

@jhedstrom