### PR TITLE
Properly use and allow 'magic override' of project.db setting.

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -7,9 +7,10 @@ module.exports = function(grunt) {
   // This will take precedence over environment or project-shipped config.
   module.magic = function (name, envName) {
     envName = envName || name;
-    return grunt.config(['gdt', name])
+
+    return grunt.config(['gdt'].concat(name))
       || process.env['GDT_' + envName.toUpperCase()]
-      || grunt.config(['config', name]);
+      || grunt.config(['config'].concat(name));
   }
 
   // Ensure a default URL for the project.
@@ -46,7 +47,7 @@ module.exports = function(grunt) {
 
     grunt.config('config.domain', module.magic('domain') || require('os').hostname());
     grunt.config('config.alias', module.magic('alias', 'SITE_ALIAS') || '@' + grunt.config('config.domain'));
-    grunt.config('config.project.profile', module.magic('profile', 'INSTALL_PROFILE') || 'standard');
+    grunt.config('config.project.profile', module.magic(['project', 'profile'], 'INSTALL_PROFILE') || 'standard');
     grunt.config('config.siteUrls', module.magic('siteUrls') || {default: module.siteUrls});
     grunt.config('config.siteUrls.default', module.siteUrls());
     grunt.config('config.buildPaths', module.buildPaths());

--- a/test/library.js
+++ b/test/library.js
@@ -79,6 +79,15 @@ describe('Initialization', function() {
       assert.equal(init.magic('test_e', 'test_epsilon'), 'Enterprise');
       done();
     });
+    it('should allow a nested value to be overridden', function(done) {
+      grunt.config.init({
+        config: { nested: { item: 'a' } }
+      });
+
+      var init = require('../lib/init')(grunt);
+      assert.equal(init.magic(['nested', 'item'], 'nested_item'), 'a');
+      done();
+    });
   });
 
 });


### PR DESCRIPTION
@arithmetric @jhedstrom 

We were clobbering the profile setting with the previous implementation. Now we can supported nested config settings in the "magic conf" loader.