### PR TITLE
Use the pv command if available for loading the database.

### DIFF
--- a/lib/drupal.js
+++ b/lib/drupal.js
@@ -85,6 +85,16 @@ module.exports = function(grunt) {
       }
       callback(error, result);
     });
+    // Check for the `pv` utility.
+    grunt.util.spawn({cmd: 'which', args: ['pv']}, function(error, result, code) {
+      if (error) {
+        // The pv command doesn't exist, simply use gzip.
+        grunt.config('config.project.gunzipCommand', 'gzip -dc <%= config.project.db %>');
+      }
+      else {
+        grunt.config('config.project.gunzipCommand', 'pv <%= config.project.db %> | gzip -dc');
+      }
+    });
   }
 
   return module;

--- a/tasks/install.js
+++ b/tasks/install.js
@@ -48,7 +48,8 @@ module.exports = function(grunt) {
     }, cmd)
   });
   grunt.config(['shell', 'loaddb'], {
-    command: 'gzip -dc <%= config.project.db %> | <%= config.project.dbConnection %>'
+    // Use the pv command if available.
+    command: '<%= config.project.gunzipCommand %> | <%= config.project.dbConnection %>'
   });
 
   grunt.registerTask('install', 'Install Drupal with the configured profile, or from a database dump file if one exists.', function() {


### PR DESCRIPTION
This successfully uses the `pv` command, but grunt, even with the `-v` option is swallowing the output. Posted here in case anybody knows how to get that output through.
