### PR TITLE
ensuring eslint only runs if there are files to test

### DIFF
--- a/tasks/quality.js
+++ b/tasks/quality.js
@@ -135,21 +135,24 @@ module.exports = function(grunt) {
       eslintConfigFile = eslintConfig.configFile || './.eslintrc',
       eslintIgnoreError = grunt.config.get('config.validate.ignoreError') === undefined ? false : grunt.config.get('config.validate.ignoreError'),
       eslintName = eslintIgnoreError ? 'force:eslint' : 'eslint';
-    grunt.config('eslint', {
-      options: {
-        configFile: eslintConfigFile
-      },
-      validate: eslintTarget,
-      analyze: {
+    
+    if (grunt.file.expand(eslintTarget).length !== 0) {
+      grunt.config('eslint', {
         options: {
-          format: 'checkstyle',
-          outputFile: '<%= config.buildPaths.reports %>/eslint.xml'
+          configFile: eslintConfigFile
         },
-        src: eslintTarget
-      }
-    });
-    validate.push(eslintName + ':validate');
-    analyze.push(eslintName + ':analyze');
+        validate: eslintTarget,
+        analyze: {
+          options: {
+            format: 'checkstyle',
+            outputFile: '<%= config.buildPaths.reports %>/eslint.xml'
+          },
+          src: eslintTarget
+        }
+      });
+      validate.push(eslintName + ':validate');
+      analyze.push(eslintName + ':analyze');
+    }
   }
 
   // If any of the themes have code quality commands, attach them here.


### PR DESCRIPTION
If I do this:

```
yo gadget --use-master
grunt
```

I get this error:

```
Running "eslint:validate" (eslint) task
Could not find any files to validate.
Warning: Task "eslint:validate" failed. Used --force, continuing.
```

This PR doesn't let the `eslint:validate` task get added to `validate` or `analyze` unless there are files to test. It's implement the same way that I solved this problem for `phpcs` in #192 