### PR TITLE
Ensuring a config setting of "eslint: false" can disable it

### DIFF
--- a/lib/drupal.js
+++ b/lib/drupal.js
@@ -68,7 +68,7 @@ module.exports = function(grunt) {
   };
 
   module.drushPath = function() {
-    return grunt.config('config.drush.cmd') !== undefined ? path.resolve(grunt.config('config.drush.cmd')) : 'drush';
+    return grunt.config('config.drush.cmd') ? path.resolve(grunt.config('config.drush.cmd')) : 'drush';
   };
 
   module.loadDatabaseConnection = function(callback) {

--- a/tasks/quality.js
+++ b/tasks/quality.js
@@ -126,7 +126,7 @@ module.exports = function(grunt) {
     analyze.push('phpmd:custom');
   }
 
-  if (grunt.config.get('config.eslint') != undefined) {
+  if (grunt.config.get('config.eslint')) {
     var eslintConfig = grunt.config.get('config.eslint'),
       eslintTarget = eslintConfig.dir || [
           '<%= config.srcPaths.drupal %>/**/*.js',

--- a/tasks/quality.js
+++ b/tasks/quality.js
@@ -44,7 +44,7 @@ module.exports = function(grunt) {
   });
   validate.push('phplint:all');
 
-  if (grunt.config.get('config.phpcs') != undefined) {
+  if (grunt.config.get('config.phpcs')) {
     var phpcs = grunt.config.get('config.phpcs.dir') || [
         '<%= config.srcPaths.drupal %>/**/*.css'
       ].concat(defaultPatterns);
@@ -108,7 +108,7 @@ module.exports = function(grunt) {
 
   }
 
-  if (grunt.config.get('config.phpmd') != undefined) {
+  if (grunt.config.get('config.phpmd')) {
     var phpmdConfig = grunt.config.get('config.phpmd.configPath') || 'phpmd.xml';
     grunt.config('phpmd', {
       custom: {


### PR DESCRIPTION
If `Gruntconfig.json` has `eslint: false` it does not turn it off; this fixes that. The check was looking to see if it wasn't undefined; both `true` and `false` are not undefined... so this moves it to a truthy check.