### PR TITLE
Preserve file modes on copy tasks

### DIFF
--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -8,37 +8,43 @@ module.exports = function(grunt) {
    */
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.config('copy.static', {
+    options: {
+      mode: true
+    },
     files: [
       {
         expand: true,
         cwd: '<%= config.srcPaths.drupal %>/static',
         src: ['**', '.**'],
         dest: '<%= config.buildPaths.html %>',
-        dot: true,
-        mode: true
+        dot: true
       }
     ]
   });
   grunt.config('copy.tempbuild', {
+    options: {
+      mode: true
+    },
     files: [
       {
         expand: true,
         cwd: '<%= config.buildPaths.temp %>',
         src: ['**', '.**'],
         dest: '<%= config.buildPaths.html %>',
-        dot: true,
-        mode: true
+        dot: true
       }
     ]
   });
   grunt.config('copy.defaults', {
+    options: {
+      mode: true
+    },
     files: [
       {
         expand: true,
         cwd: '<%= config.buildPaths.html %>/sites/default',
         src: ['default*'],
-        dest: '<%= config.srcPaths.drupal %>/sites/default',
-        mode: true
+        dest: '<%= config.srcPaths.drupal %>/sites/default'
       }
     ]
   });

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -14,7 +14,8 @@ module.exports = function(grunt) {
         cwd: '<%= config.srcPaths.drupal %>/static',
         src: ['**', '.**'],
         dest: '<%= config.buildPaths.html %>',
-        dot: true
+        dot: true,
+        mode: true
       }
     ]
   });
@@ -25,7 +26,8 @@ module.exports = function(grunt) {
         cwd: '<%= config.buildPaths.temp %>',
         src: ['**', '.**'],
         dest: '<%= config.buildPaths.html %>',
-        dot: true
+        dot: true,
+        mode: true
       }
     ]
   });
@@ -35,7 +37,8 @@ module.exports = function(grunt) {
         expand: true,
         cwd: '<%= config.buildPaths.html %>/sites/default',
         src: ['default*'],
-        dest: '<%= config.srcPaths.drupal %>/sites/default'
+        dest: '<%= config.srcPaths.drupal %>/sites/default',
+        mode: true
       }
     ]
   });

--- a/tasks/package.js
+++ b/tasks/package.js
@@ -27,19 +27,18 @@ module.exports = function(grunt) {
           cwd: '<%= config.buildPaths.html %>',
           src: srcFiles,
           dest: destPath + (grunt.config.get('config.packages.dest.docroot') || ''),
-          dot: true,
-          mode: true
+          dot: true
         },
         {
           expand: true,
           src: projFiles,
           dest: destPath + (grunt.config.get('config.packages.dest.devResources') || ''),
-          dot: true,
-          mode: true
+          dot: true
         }
       ],
       options: {
-        gruntLogHeader: false
+        gruntLogHeader: false,
+        mode: true
       }
     });
 

--- a/tasks/package.js
+++ b/tasks/package.js
@@ -27,13 +27,15 @@ module.exports = function(grunt) {
           cwd: '<%= config.buildPaths.html %>',
           src: srcFiles,
           dest: destPath + (grunt.config.get('config.packages.dest.docroot') || ''),
-          dot: true
+          dot: true,
+          mode: true
         },
         {
           expand: true,
           src: projFiles,
           dest: destPath + (grunt.config.get('config.packages.dest.devResources') || ''),
-          dot: true
+          dot: true,
+          mode: true
         }
       ],
       options: {


### PR DESCRIPTION
Configuring the copy tasks to preserve file mode with 'mode: true'.

By default, grunt-contrib-copy sets the mode to 0644 when it copies files. See: https://github.com/gruntjs/grunt-contrib-copy#mode
