### PR TITLE
adding ability to skip `grunt:validate` step to default task

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ These flags are not yet documented as part of the `grunt help` command.
 * `--notify`: Request a desktop notification despite timing or environment settings.
 * `--timer`: Output execution time profile at the end of the task run.
 * `--concurrency`: Override the dynamic concurrency by Drush Make.
+* `--no-validate`: Skip `grunt:validate` in the default `grunt` task.
 
 ### Environment Options
 

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -32,9 +32,12 @@ module.exports = function(grunt) {
   grunt.loadTasks(__dirname + '/tasks');
 
   // Define the default task to fully build and configure the project.
-  var tasksDefault = [
-    'validate'
-  ];
+  var tasksDefault = [];
+
+  // If the "--no-validate" option is given, skip adding "validate" to task array.
+  if (!grunt.option('no-validate')) {
+    tasksDefault.push('validate');
+  }
 
   // If build/html exists, but is empty, skip the newer check.
   // This facilitates situations where the build/html is generated as a mounted

--- a/tasks/help.js
+++ b/tasks/help.js
@@ -47,6 +47,7 @@ module.exports = function(grunt) {
         [ '--notify', 'Request a desktop notification despite timing or environment settings.' ],
         [ '--timer', 'Output task execution timing info.' ],
         [ '--concurrency', 'Override the dynamic concurrency parameter used by Drush Make.' ],
+        [ '--no-validate', 'Skip `grunt:validate` in the default `grunt` task.' ],
         [ '--db-url', 'Pass thru your Drupal database credentials for site installation.' ]
       ];
 


### PR DESCRIPTION
This PR continues work from #193, but moves the branch to this repo.
