### PR TITLE
Scale back default validation patterns for phpcs/phplint and eslint

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -373,10 +373,10 @@ This is an example of the settings for the validate tasks:
   }
   "phplint": {
     "dir": [
-      '<%= config.srcPaths.drupal %>/themes/atmos_energy/template.php',
-      '<%= config.srcPaths.drupal %>/themes/atmos_energy/templates/**/*.php',
-      '<%= config.srcPaths.drupal %>/themes/atmos_energy/includes/**/*.{inc,php}',
       '<%= config.srcPaths.drupal %>/sites/**/*.{php,inc}',
+      '<%= config.srcPaths.drupal %>/themes/*/template.php',
+      '<%= config.srcPaths.drupal %>/themes/*/templates/**/*.php',
+      '<%= config.srcPaths.drupal %>/themes/*/includes/**/*.{inc,php}',
       '<%= config.srcPaths.drupal %>/{modules,profiles,libraries,static}/**/*.{php,module,inc,install,profile}',
       '!<%= config.srcPaths.drupal %>/{modules,profiles,libraries,static}/**/*.{box,pages_default,views_default,panelizer,strongarm}.inc',
       '!<%= config.srcPaths.drupal %>/{modules,profiles,libraries,static}/**/*.features.*inc',
@@ -403,7 +403,7 @@ review by eslint. The following is used by default:
   "eslint": {
     "dir": [
       'src/themes/*/js/**/*.js',
-      'src/{modules,profiles}/**/*.js'
+      'src/{modules,profiles,libraries}/**/*.js'
     ]
   }
 }

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -363,9 +363,8 @@ This is an example of the settings for the validate tasks:
 {
   "eslint": {
     "dir": [
-      '<%= config.srcPaths.drupal %>/**/*.js',
-      '!<%= config.srcPaths.drupal %>/**/bower/**/*.js',
-      '!<%= config.srcPaths.drupal %>/sites/**/files/**/*.js'
+      '<%= config.srcPaths.drupal %>/themes/*/js/**/*.js',
+      '<%= config.srcPaths.drupal %>/{modules,profiles}/**/*.js'
     ]
   },
   "phpcs": {
@@ -374,12 +373,11 @@ This is an example of the settings for the validate tasks:
   }
   "phplint": {
     "dir": [
-      "<%= config.srcPaths.drupal %>/**/*.php",
-      "<%= config.srcPaths.drupal %>/**/*.module",
-      "<%= config.srcPaths.drupal %>/**/*.inc",
-      "<%= config.srcPaths.drupal %>/**/*.install",
-      "<%= config.srcPaths.drupal %>/**/*.profile",
-      "!<%= config.srcPaths.drupal %>/**/vendor/**",
+      '<%= config.srcPaths.drupal %>/{modules,profiles}/**/*.{php,module,inc,install,profile}',
+      '!<%= config.srcPaths.drupal %>/{modules,profiles}/**/*.{box,pages_default,views_default,panelizer,strongarm}.inc',
+      '!<%= config.srcPaths.drupal %>/{modules,profiles}/**/*.features.*inc',
+      '!<%= config.srcPaths.drupal %>/{modules,profiles}/**/*.tpl.php',
+      '!<%= config.srcPaths.drupal %>/{modules,profiles}/**/vendor/**'
     ]
   }
 }
@@ -425,20 +423,11 @@ with grunt-drupal-tasks:
   "phpcs": {
     "path": "vendor/bin/phpcs",
     "dir": [
-      "<%= config.srcPaths.drupal %>/**/*.php",
-      "<%= config.srcPaths.drupal %>/**/*.module",
-      "<%= config.srcPaths.drupal %>/**/*.inc",
-      "<%= config.srcPaths.drupal %>/**/*.install",
-      "<%= config.srcPaths.drupal %>/**/*.profile",
-      "!<%= config.srcPaths.drupal %>/sites/**",
-      "!<%= config.srcPaths.drupal %>/**/*.box.inc",
-      "!<%= config.srcPaths.drupal %>/**/*.features.*inc",
-      "!<%= config.srcPaths.drupal %>/**/*.pages_default.inc",
-      "!<%= config.srcPaths.drupal %>/**/*.panelizer.inc",
-      "!<%= config.srcPaths.drupal %>/**/*.strongarm.inc",
-      "!<%= config.srcPaths.drupal %>/**/*.css",
-      "!<%= config.srcPaths.drupal %>/**/*/pattern-lab/**/*",
-      "!<%= config.srcPaths.drupal %>/**/*/bower_components/**/*"
+      '<%= config.srcPaths.drupal %>/{modules,profiles}/**/*.{php,module,inc,install,profile}',
+      '!<%= config.srcPaths.drupal %>/{modules,profiles}/**/*.{box,pages_default,views_default,panelizer,strongarm}.inc',
+      '!<%= config.srcPaths.drupal %>/{modules,profiles}/**/*.features.*inc',
+      '!<%= config.srcPaths.drupal %>/{modules,profiles}/**/*.tpl.php',
+      '!<%= config.srcPaths.drupal %>/{modules,profiles}/**/vendor/**'
     ]
   }
 }

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -364,7 +364,7 @@ This is an example of the settings for the validate tasks:
   "eslint": {
     "dir": [
       '<%= config.srcPaths.drupal %>/themes/*/js/**/*.js',
-      '<%= config.srcPaths.drupal %>/{modules,profiles}/**/*.js'
+      '<%= config.srcPaths.drupal %>/{modules,profiles,libraries}/**/*.js'
     ]
   },
   "phpcs": {
@@ -402,8 +402,8 @@ review by eslint. The following is used by default:
 {
   "eslint": {
     "dir": [
-      'src/themes/*/js/**/*.js',
-      'src/{modules,profiles,libraries}/**/*.js'
+      '<%= config.srcPaths.drupal %>/themes/*/js/**/*.js',
+      '<%= config.srcPaths.drupal %>/{modules,profiles,libraries}/**/*.js'
     ]
   }
 }

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -373,11 +373,14 @@ This is an example of the settings for the validate tasks:
   }
   "phplint": {
     "dir": [
-      '<%= config.srcPaths.drupal %>/{modules,profiles}/**/*.{php,module,inc,install,profile}',
-      '!<%= config.srcPaths.drupal %>/{modules,profiles}/**/*.{box,pages_default,views_default,panelizer,strongarm}.inc',
-      '!<%= config.srcPaths.drupal %>/{modules,profiles}/**/*.features.*inc',
-      '!<%= config.srcPaths.drupal %>/{modules,profiles}/**/*.tpl.php',
-      '!<%= config.srcPaths.drupal %>/{modules,profiles}/**/vendor/**'
+      '<%= config.srcPaths.drupal %>/themes/atmos_energy/template.php',
+      '<%= config.srcPaths.drupal %>/themes/atmos_energy/templates/**/*.php',
+      '<%= config.srcPaths.drupal %>/themes/atmos_energy/includes/**/*.{inc,php}',
+      '<%= config.srcPaths.drupal %>/sites/**/*.{php,inc}',
+      '<%= config.srcPaths.drupal %>/{modules,profiles,libraries,static}/**/*.{php,module,inc,install,profile}',
+      '!<%= config.srcPaths.drupal %>/{modules,profiles,libraries,static}/**/*.{box,pages_default,views_default,panelizer,strongarm}.inc',
+      '!<%= config.srcPaths.drupal %>/{modules,profiles,libraries,static}/**/*.features.*inc',
+      '!<%= config.srcPaths.drupal %>/{modules,profiles,libraries,static}/**/vendor/**'
     ]
   }
 }
@@ -399,8 +402,8 @@ review by eslint. The following is used by default:
 {
   "eslint": {
     "dir": [
-      '<%= config.srcPaths.drupal %>/**/*.js',
-      '!<%= config.srcPaths.drupal %>/sites/**/files/**/*.js'
+      'src/themes/*/js/**/*.js',
+      'src/{modules,profiles}/**/*.js'
     ]
   }
 }
@@ -423,11 +426,11 @@ with grunt-drupal-tasks:
   "phpcs": {
     "path": "vendor/bin/phpcs",
     "dir": [
-      '<%= config.srcPaths.drupal %>/{modules,profiles}/**/*.{php,module,inc,install,profile}',
-      '!<%= config.srcPaths.drupal %>/{modules,profiles}/**/*.{box,pages_default,views_default,panelizer,strongarm}.inc',
-      '!<%= config.srcPaths.drupal %>/{modules,profiles}/**/*.features.*inc',
-      '!<%= config.srcPaths.drupal %>/{modules,profiles}/**/*.tpl.php',
-      '!<%= config.srcPaths.drupal %>/{modules,profiles}/**/vendor/**'
+      '<%= config.srcPaths.drupal %>/{modules,profiles,libraries,static}/**/*.{php,module,inc,install,profile}',
+      '!<%= config.srcPaths.drupal %>/{modules,profiles,libraries,static}/**/*.{box,pages_default,views_default,panelizer,strongarm}.inc',
+      '!<%= config.srcPaths.drupal %>/{modules,profiles,libraries,static}/**/*.features.*inc',
+      '!<%= config.srcPaths.drupal %>/{modules,profiles,libraries,static}/**/vendor/**',
+      '!<%= config.srcPaths.drupal %>/{modules,profiles,libraries,static}/**/*.tpl.php'
     ]
   }
 }

--- a/example/.eslintrc
+++ b/example/.eslintrc
@@ -23,7 +23,6 @@
     "no-use-before-define": 0,
     "consistent-return": 0,
     "no-constant-condition": 0,
-    "no-comma-dangle" : 2,
     "no-catch-shadow" : 2
   }
 }

--- a/tasks/quality.js
+++ b/tasks/quality.js
@@ -216,7 +216,9 @@ module.exports = function(grunt) {
   grunt.registerTask('analyze', 'Generate reports on code quality for use by Jenkins or other visualization tools.', function() {
     var phpcs = grunt.config.get('phpcs.analyze');
     if (phpcs) {
-      if (filesToProcess(phpcs.src).length) {
+      var files = filesToProcess(phpcs.src);
+      if (files.length) {
+        grunt.config.set('phpcs.analyze', files);
         analyze.push('phpcs:analyze');
       }
     }
@@ -225,7 +227,9 @@ module.exports = function(grunt) {
       eslintName = eslintIgnoreError ? 'force:eslint' : 'eslint';
     if (eslint) {
       // The eslint:analyze task has a deeper configuration structure than eslint:validate.
-      if (filesToProcess(eslint.src).length) {
+      var files = filesToProcess(eslint.src);
+      if (files.length) {
+        grunt.config.set('eslint.analyze', files);
         analyze.push(eslintName + ':analyze');
       }
     }

--- a/tasks/quality.js
+++ b/tasks/quality.js
@@ -176,14 +176,16 @@ module.exports = function(grunt) {
       return grunt.template.process(item);
     });
 
-    // If this is evaluated to truthy at least one file matched.
+    // If length is evaluated to truthy at least one file matched.
     return grunt.file.expand(paths);
   }
 
   grunt.registerTask('validate', 'Validate the quality of custom code.', function(mode) {
     var phpcs = grunt.config.get('phpcs.validate');
     if (phpcs) {
-      if (filesToProcess(phpcs.src)) {
+      var files = filesToProcess(phpcs.src);
+      if (files.length) {
+        grunt.config.set('phpcs.validate.src', files);
         validate.push('phpcs:validate');
       }
     }
@@ -191,7 +193,9 @@ module.exports = function(grunt) {
       eslintIgnoreError = grunt.config.get('config.validate.ignoreError') === undefined ? false : grunt.config.get('config.validate.ignoreError'),
       eslintName = eslintIgnoreError ? 'force:eslint' : 'eslint';
     if (eslint) {
-      if (filesToProcess(eslint)) {
+      var files = filesToProcess(eslint);
+      if (files.length) {
+        grunt.config.set('eslint.validate', files);
         validate.push(eslintName + ':validate');
       }
     }
@@ -212,7 +216,7 @@ module.exports = function(grunt) {
   grunt.registerTask('analyze', 'Generate reports on code quality for use by Jenkins or other visualization tools.', function() {
     var phpcs = grunt.config.get('phpcs.analyze');
     if (phpcs) {
-      if (filesToProcess(phpcs.src)) {
+      if (filesToProcess(phpcs.src).length) {
         analyze.push('phpcs:analyze');
       }
     }
@@ -221,7 +225,7 @@ module.exports = function(grunt) {
       eslintName = eslintIgnoreError ? 'force:eslint' : 'eslint';
     if (eslint) {
       // The eslint:analyze task has a deeper configuration structure than eslint:validate.
-      if (filesToProcess(eslint.src)) {
+      if (filesToProcess(eslint.src).length) {
         analyze.push(eslintName + ':analyze');
       }
     }

--- a/tasks/quality.js
+++ b/tasks/quality.js
@@ -36,15 +36,12 @@ module.exports = function(grunt) {
 
   // Include common sites and theme locations in phplint validation.
   var phplintPatterns = defaultPatterns.slice(0);
-  phplintPatterns.unshift('<%= config.srcPaths.drupal %>/sites/**/*.{php,inc}');
-
-  for (var key in themes) {
-    phplintPatterns.unshift.apply(phplintPatterns, [
-      '<%= config.srcPaths.drupal %>/themes/' + key + '/template.php',
-      '<%= config.srcPaths.drupal %>/themes/' + key + '/templates/**/*.php',
-      '<%= config.srcPaths.drupal %>/themes/' + key + '/includes/**/*.{inc,php}'
-    ]);
-  }
+  phplintPatterns.unshift.apply(phplintPatterns, [
+    '<%= config.srcPaths.drupal %>/sites/**/*.{php,inc}',
+    '<%= config.srcPaths.drupal %>/themes/*/template.php',
+    '<%= config.srcPaths.drupal %>/themes/*/templates/**/*.php',
+    '<%= config.srcPaths.drupal %>/themes/*/includes/**/*.{inc,php}'
+  ]);
 
   grunt.config('phplint', {
     all: grunt.config.get('config.phplint.dir') ? grunt.config.get('config.phplint.dir') : phplintPatterns
@@ -143,7 +140,7 @@ module.exports = function(grunt) {
     var eslintConfig = grunt.config.get('config.eslint'),
       eslintTarget = eslintConfig.dir || [
           '<%= config.srcPaths.drupal %>/themes/*/js/**/*.js',
-          '<%= config.srcPaths.drupal %>/{modules,profiles}/**/*.js'
+          '<%= config.srcPaths.drupal %>/{modules,profiles,libraries}/**/*.js'
         ],
       eslintTargetAnalyze = eslintTarget,
       eslintConfigFile = eslintConfig.configFile || './.eslintrc',

--- a/tasks/quality.js
+++ b/tasks/quality.js
@@ -27,17 +27,11 @@ module.exports = function(grunt) {
   var analyze = [];
 
   var defaultPatterns = [
-    '<%= config.srcPaths.drupal %>/**/*.php',
-    '<%= config.srcPaths.drupal %>/**/*.module',
-    '<%= config.srcPaths.drupal %>/**/*.inc',
-    '<%= config.srcPaths.drupal %>/**/*.install',
-    '<%= config.srcPaths.drupal %>/**/*.profile',
-    '!<%= config.srcPaths.drupal %>/sites/**',
-    '!<%= config.srcPaths.drupal %>/**/*.box.inc',
-    '!<%= config.srcPaths.drupal %>/**/*.features.*inc',
-    '!<%= config.srcPaths.drupal %>/**/*.pages_default.inc',
-    '!<%= config.srcPaths.drupal %>/**/*.panelizer.inc',
-    '!<%= config.srcPaths.drupal %>/**/*.strongarm.inc'
+    '<%= config.srcPaths.drupal %>/{modules,profiles}/**/*.{php,module,inc,install,profile}',
+    '!<%= config.srcPaths.drupal %>/{modules,profiles}/**/*.{box,pages_default,views_default,panelizer,strongarm}.inc',
+    '!<%= config.srcPaths.drupal %>/{modules,profiles}/**/*.features.*inc',
+    '!<%= config.srcPaths.drupal %>/{modules,profiles}/**/*.tpl.php',
+    '!<%= config.srcPaths.drupal %>/{modules,profiles}/**/vendor/**'
   ];
 
   grunt.config('phplint', {
@@ -46,9 +40,7 @@ module.exports = function(grunt) {
   validate.push('phplint:all');
 
   if (grunt.config.get('config.phpcs')) {
-    var phpcs = grunt.config.get('config.phpcs.dir') || [
-        '<%= config.srcPaths.drupal %>/**/*.css'
-      ].concat(defaultPatterns);
+    var phpcs = grunt.config.get('config.phpcs.dir') || defaultPatterns;
 
     var phpStandard = grunt.config('config.phpcs.standard')
       || 'vendor/drupal/coder/coder_sniffer/Drupal';
@@ -135,8 +127,8 @@ module.exports = function(grunt) {
   if (grunt.config.get('config.eslint')) {
     var eslintConfig = grunt.config.get('config.eslint'),
       eslintTarget = eslintConfig.dir || [
-          '<%= config.srcPaths.drupal %>/**/*.js',
-          '!<%= config.srcPaths.drupal %>/sites/**/files/**/*.js'
+          '<%= config.srcPaths.drupal %>/themes/*/js/**/*.js',
+          '<%= config.srcPaths.drupal %>/{modules,profiles}/**/*.js'
         ],
       eslintTargetAnalyze = eslintTarget,
       eslintConfigFile = eslintConfig.configFile || './.eslintrc',
@@ -147,12 +139,12 @@ module.exports = function(grunt) {
       if (themes[key].scripts && themes[key].scripts.validate) {
         // If the theme has a validate task of it's own, then exclude its
         // javascript files from our validate process.
-        eslintTarget.push('!<%= config.srcPaths.drupal %>/themes/' + key + '/**/*.js');
+        eslintTarget.push('!<%= config.srcPaths.drupal %>/themes/' + key + '/js/**/*.js');
       }
       if (themes[key].scripts && themes[key].scripts.analyze) {
         // If the theme has an analyze task of it's own, then exclude its
         // javascript files from our analyze process.
-        eslintTargetAnalyze.push('!<%= config.srcPaths.drupal %>/themes/' + key + '/**/*.js');
+        eslintTargetAnalyze.push('!<%= config.srcPaths.drupal %>/themes/' + key + '/js/**/*.js');
       }
     }
 


### PR DESCRIPTION
This adds a more restrictive set of default validation patterns, avoiding excessive globbing particularly in locations that might contain node_modules or similarly large directory trees. Although the existing patterns exclude these large directories from linting, patterns that match these directories (inclusive or exclusive) incur a filesystem stat which can decrease performance, especially with the recursive nature of node_modules with npm < 3. 

The summary of changes is:

1. No top-level globstar in any pattern to avoid recursing through `src/themes`, exclusive or inclusive
2. Scope php validation to the modules & profiles directories **only**.
3. Limit eslint to `themes/<theme_dir>/js` to avoid globbing through node_modules and bower_components.
4. Adjusted some defaults for common false positives and generated code.

These changes err on the side of scanning as few directories as possible while still picking up the files that we actually care about. Project-specific tweaks can add more targeted patterns as needed.