### PR TITLE
Removing peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 Code Status (master branch):
 [![Travis CI status](https://travis-ci.org/phase2/grunt-drupal-tasks.svg?branch=master)](https://travis-ci.org/phase2/grunt-drupal-tasks)
 [![Dependency Status](https://david-dm.org/phase2/grunt-drupal-tasks.svg)](https://david-dm.org/phase2/grunt-drupal-tasks)
-[![Peer Dependency Status](https://david-dm.org/phase2/grunt-drupal-tasks/peer-status.svg)](https://david-dm.org/phase2/grunt-drupal-tasks#peer-badge-embed)
 [![npm version](https://badge.fury.io/js/grunt-drupal-tasks.svg)](https://www.npmjs.com/package/grunt-drupal-tasks)
 
 ## Requirements

--- a/package.json
+++ b/package.json
@@ -30,9 +30,6 @@
     "lodash": "^3.10.1",
     "time-grunt": "^1.3.0"
   },
-  "peerDependencies": {
-    "grunt": ">= 0.4.5 < 0.5"
-  },
   "engines": {
     "node": ">=0.10.0"
   },


### PR DESCRIPTION
Since the role of peer dependencies is changing in npm and they interfere with new releases of Grunt (prompted by #236), let's remove the peer dependencies section of package.json.

The example package.json includes a dependency on grunt, so the need for the peer dependency in Grunt Drupal Tasks is not clear.
