### PR TITLE
Faster rsync for tempbuild step in non-Windows environments.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -7,5 +7,10 @@ module.exports = {
     return paths.map(function(value, index, arr) {
       return baseUrl + value;
     });
+  },
+  canRsync: function() {
+    // Enable process.platform to be mocked in options for testing.
+    var platform = options.platform || process.platform;
+    return platform === "win32";
   }
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -11,6 +11,6 @@ module.exports = {
   canRsync: function() {
     // Enable process.platform to be mocked in options for testing.
     var platform = options.platform || process.platform;
-    return platform === "win32";
+    return platform !== "win32";
   }
 };

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,554 +1,552 @@
 {
   "name": "grunt-drupal-tasks",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "dependencies": {
     "abbrev": {
       "version": "1.0.7",
-      "from": "abbrev@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
     },
     "amdefine": {
       "version": "1.0.0",
-      "from": "amdefine@>=0.0.4",
+      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
     },
     "ansi-escapes": {
       "version": "1.1.0",
-      "from": "ansi-escapes@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.1.0.tgz"
     },
     "ansi-regex": {
       "version": "2.0.0",
-      "from": "ansi-regex@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
     },
     "ansi-styles": {
       "version": "2.1.0",
-      "from": "ansi-styles@>=2.1.0 <3.0.0",
+      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
     },
     "archiver": {
       "version": "0.16.0",
-      "from": "archiver@>=0.16.0 <0.17.0",
+      "from": "https://registry.npmjs.org/archiver/-/archiver-0.16.0.tgz",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.16.0.tgz",
       "dependencies": {
         "async": {
           "version": "1.4.2",
-          "from": "async@>=1.4.2 <1.5.0",
+          "from": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz"
         },
         "readable-stream": {
           "version": "1.0.33",
-          "from": "readable-stream@>=1.0.26 <1.1.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
         }
       }
     },
     "argparse": {
       "version": "1.0.3",
-      "from": "argparse@>=1.0.2 <2.0.0",
+      "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz"
     },
     "array-union": {
       "version": "1.0.1",
-      "from": "array-union@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz"
     },
     "array-uniq": {
       "version": "1.0.2",
-      "from": "array-uniq@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
     },
     "arrify": {
       "version": "1.0.0",
-      "from": "arrify@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
     },
     "async": {
       "version": "1.5.0",
-      "from": "async@>=1.2.1 <2.0.0",
+      "from": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
     },
     "balanced-match": {
       "version": "0.2.1",
-      "from": "balanced-match@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
     },
     "bin-version": {
       "version": "1.0.4",
-      "from": "bin-version@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz"
     },
     "bin-version-check": {
       "version": "2.1.0",
-      "from": "bin-version-check@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
       "dependencies": {
         "semver": {
           "version": "4.3.6",
-          "from": "semver@>=4.0.3 <5.0.0",
+          "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         }
       }
     },
     "bl": {
       "version": "1.0.0",
-      "from": "bl@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
     },
     "brace-expansion": {
       "version": "1.1.1",
-      "from": "brace-expansion@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz"
     },
     "buffer-crc32": {
       "version": "0.2.5",
-      "from": "buffer-crc32@>=0.2.1 <0.3.0",
+      "from": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz"
     },
     "builtin-modules": {
       "version": "1.1.0",
-      "from": "builtin-modules@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
     },
     "cache-swap": {
       "version": "0.0.6",
-      "from": "cache-swap@>=0.0.2 <0.1.0",
+      "from": "https://registry.npmjs.org/cache-swap/-/cache-swap-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/cache-swap/-/cache-swap-0.0.6.tgz",
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "from": "async@>=0.2.6 <0.3.0",
+          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-        },
-        "lodash": {
-          "version": "1.1.1",
-          "from": "lodash@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.1.1.tgz"
         },
         "rimraf": {
           "version": "2.1.4",
-          "from": "rimraf@>=2.1.4 <2.2.0",
+          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.1.4.tgz",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.1.4.tgz"
+        },
+        "lodash": {
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.1.1.tgz"
         },
         "graceful-fs": {
           "version": "1.2.3",
-          "from": "graceful-fs@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
         }
       }
     },
     "camelcase": {
       "version": "1.2.1",
-      "from": "camelcase@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
     },
     "camelcase-keys": {
       "version": "1.0.0",
-      "from": "camelcase-keys@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz"
     },
     "chalk": {
       "version": "1.1.1",
-      "from": "chalk@>=1.1.1 <2.0.0",
+      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
     },
     "cli-cursor": {
       "version": "1.0.2",
-      "from": "cli-cursor@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz"
     },
     "cli-width": {
       "version": "1.1.0",
-      "from": "cli-width@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.0.tgz"
     },
     "code-point-at": {
       "version": "1.0.0",
-      "from": "code-point-at@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz"
     },
     "compress-commons": {
       "version": "0.3.0",
-      "from": "compress-commons@>=0.3.0 <0.4.0",
+      "from": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.3.0.tgz",
       "dependencies": {
         "readable-stream": {
           "version": "1.0.33",
-          "from": "readable-stream@>=1.0.26 <1.1.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
         }
       }
     },
     "concat-map": {
       "version": "0.0.1",
-      "from": "concat-map@0.0.1",
+      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
     },
     "concat-stream": {
       "version": "1.5.1",
-      "from": "concat-stream@>=1.4.6 <2.0.0",
+      "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz"
     },
     "core-util-is": {
       "version": "1.0.1",
-      "from": "core-util-is@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
     },
     "crc32-stream": {
       "version": "0.3.4",
-      "from": "crc32-stream@>=0.3.1 <0.4.0",
+      "from": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.3.4.tgz",
       "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.3.4.tgz",
       "dependencies": {
         "readable-stream": {
           "version": "1.0.33",
-          "from": "readable-stream@>=1.0.24 <1.1.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
         }
       }
     },
     "d": {
       "version": "0.1.1",
-      "from": "d@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
     },
     "dargs": {
       "version": "2.1.0",
-      "from": "dargs@>=2.0.3 <3.0.0",
+      "from": "https://registry.npmjs.org/dargs/-/dargs-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/dargs/-/dargs-2.1.0.tgz"
     },
     "date-time": {
       "version": "1.0.0",
-      "from": "date-time@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/date-time/-/date-time-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/date-time/-/date-time-1.0.0.tgz"
     },
     "debug": {
       "version": "0.7.4",
-      "from": "debug@>=0.7.0 <0.8.0",
+      "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
       "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
     },
     "decamelize": {
       "version": "1.1.1",
-      "from": "decamelize@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
     },
     "deep-is": {
       "version": "0.1.3",
-      "from": "deep-is@>=0.1.3 <0.2.0",
+      "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
     },
     "del": {
       "version": "2.0.2",
-      "from": "del@>=2.0.2 <3.0.0",
+      "from": "https://registry.npmjs.org/del/-/del-2.0.2.tgz",
       "resolved": "https://registry.npmjs.org/del/-/del-2.0.2.tgz"
     },
     "doctrine": {
       "version": "0.7.0",
-      "from": "doctrine@>=0.7.0 <0.8.0",
+      "from": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.0.tgz",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.0.tgz",
       "dependencies": {
         "esutils": {
           "version": "1.1.6",
-          "from": "esutils@>=1.1.6 <2.0.0",
+          "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
           "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
         }
       }
     },
     "duplexify": {
       "version": "3.4.2",
-      "from": "duplexify@>=3.1.2 <4.0.0",
+      "from": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz"
     },
     "end-of-stream": {
       "version": "1.0.0",
-      "from": "end-of-stream@1.0.0",
+      "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz"
     },
     "error-ex": {
       "version": "1.3.0",
-      "from": "error-ex@>=1.2.0 <2.0.0",
+      "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz"
     },
     "es5-ext": {
       "version": "0.10.8",
-      "from": "es5-ext@>=0.10.8 <0.11.0",
+      "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.8.tgz",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.8.tgz"
     },
     "es6-iterator": {
       "version": "2.0.0",
-      "from": "es6-iterator@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
     },
     "es6-map": {
       "version": "0.1.2",
-      "from": "es6-map@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.2.tgz"
     },
     "es6-set": {
       "version": "0.1.2",
-      "from": "es6-set@>=0.1.2 <0.2.0",
+      "from": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.2.tgz"
     },
     "es6-symbol": {
       "version": "3.0.1",
-      "from": "es6-symbol@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.1.tgz"
     },
     "es6-weak-map": {
       "version": "0.1.4",
-      "from": "es6-weak-map@>=0.1.2 <0.2.0",
+      "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
       "dependencies": {
         "es6-iterator": {
           "version": "0.1.3",
-          "from": "es6-iterator@>=0.1.3 <0.2.0",
+          "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
           "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
         },
         "es6-symbol": {
           "version": "2.0.1",
-          "from": "es6-symbol@>=2.0.1 <2.1.0",
+          "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
         }
       }
     },
     "escape-string-regexp": {
       "version": "1.0.3",
-      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
     },
     "escope": {
       "version": "3.2.0",
-      "from": "escope@>=3.2.0 <4.0.0",
+      "from": "https://registry.npmjs.org/escope/-/escope-3.2.0.tgz",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.2.0.tgz",
       "dependencies": {
         "estraverse": {
           "version": "3.1.0",
-          "from": "estraverse@>=3.1.0 <4.0.0",
+          "from": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
         }
       }
     },
     "eslint": {
       "version": "1.9.0",
-      "from": "eslint@>=1.5.1 <2.0.0",
+      "from": "https://registry.npmjs.org/eslint/-/eslint-1.9.0.tgz",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.9.0.tgz",
       "dependencies": {
         "debug": {
           "version": "2.2.0",
-          "from": "debug@>=2.1.1 <3.0.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
         },
         "shelljs": {
           "version": "0.5.3",
-          "from": "shelljs@>=0.5.3 <0.6.0",
+          "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
           "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz"
         }
       }
     },
     "espree": {
       "version": "2.2.5",
-      "from": "espree@>=2.2.4 <3.0.0",
+      "from": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz",
       "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
     },
     "esrecurse": {
       "version": "3.1.1",
-      "from": "esrecurse@>=3.1.1 <4.0.0",
+      "from": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz",
       "dependencies": {
         "estraverse": {
           "version": "3.1.0",
-          "from": "estraverse@>=3.1.0 <3.2.0",
+          "from": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
         }
       }
     },
     "estraverse": {
       "version": "4.1.1",
-      "from": "estraverse@>=4.1.1 <5.0.0",
+      "from": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
     },
     "estraverse-fb": {
       "version": "1.3.1",
-      "from": "estraverse-fb@>=1.3.1 <2.0.0",
+      "from": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
     },
     "esutils": {
       "version": "2.0.2",
-      "from": "esutils@>=2.0.2 <3.0.0",
+      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
     },
     "event-emitter": {
       "version": "0.3.4",
-      "from": "event-emitter@>=0.3.4 <0.4.0",
+      "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
     },
     "exit-hook": {
       "version": "1.1.1",
-      "from": "exit-hook@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
     },
     "fast-levenshtein": {
       "version": "1.0.7",
-      "from": "fast-levenshtein@>=1.0.6 <1.1.0",
+      "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
     },
     "faye-websocket": {
       "version": "0.4.4",
-      "from": "faye-websocket@>=0.4.3 <0.5.0",
+      "from": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz"
     },
     "figures": {
       "version": "1.4.0",
-      "from": "figures@>=1.3.5 <2.0.0",
+      "from": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
     },
     "file-entry-cache": {
       "version": "1.2.4",
-      "from": "file-entry-cache@>=1.1.1 <2.0.0",
+      "from": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz"
     },
     "file-sync-cmp": {
       "version": "0.1.1",
-      "from": "file-sync-cmp@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz"
     },
     "find-up": {
       "version": "1.0.0",
-      "from": "find-up@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/find-up/-/find-up-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.0.0.tgz"
     },
     "find-versions": {
       "version": "1.1.3",
-      "from": "find-versions@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/find-versions/-/find-versions-1.1.3.tgz",
       "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-1.1.3.tgz"
     },
     "flat-cache": {
       "version": "1.0.10",
-      "from": "flat-cache@>=1.0.9 <2.0.0",
+      "from": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.10.tgz",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.10.tgz"
     },
     "gaze": {
       "version": "0.5.2",
-      "from": "gaze@>=0.5.1 <0.6.0",
+      "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz"
     },
     "generate-function": {
       "version": "2.0.0",
-      "from": "generate-function@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
     },
     "generate-object-property": {
       "version": "1.2.0",
-      "from": "generate-object-property@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
     },
     "get-stdin": {
       "version": "4.0.1",
-      "from": "get-stdin@>=4.0.1 <5.0.0",
+      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
     },
     "glob": {
       "version": "5.0.15",
-      "from": "glob@>=5.0.0 <5.1.0",
+      "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
       "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
     },
     "globals": {
       "version": "8.11.0",
-      "from": "globals@>=8.11.0 <9.0.0",
+      "from": "https://registry.npmjs.org/globals/-/globals-8.11.0.tgz",
       "resolved": "https://registry.npmjs.org/globals/-/globals-8.11.0.tgz"
     },
     "globby": {
       "version": "3.0.1",
-      "from": "globby@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/globby/-/globby-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/globby/-/globby-3.0.1.tgz"
     },
     "globule": {
       "version": "0.1.0",
-      "from": "globule@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
       "dependencies": {
-        "glob": {
-          "version": "3.1.21",
-          "from": "glob@>=3.1.21 <3.2.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz"
-        },
         "lodash": {
           "version": "1.0.2",
-          "from": "lodash@>=1.0.1 <1.1.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+        },
+        "glob": {
+          "version": "3.1.21",
+          "from": "glob@3.1.21",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@>=0.2.11 <0.3.0",
+          "from": "minimatch@0.2.14",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
         },
         "graceful-fs": {
           "version": "1.2.3",
-          "from": "graceful-fs@>=1.2.0 <1.3.0",
+          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
         },
         "inherits": {
           "version": "1.0.2",
-          "from": "inherits@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
         }
       }
     },
     "graceful-fs": {
       "version": "4.1.2",
-      "from": "graceful-fs@>=4.1.2 <5.0.0",
+      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
     },
     "grunt": {
       "version": "0.4.5",
-      "from": "grunt@>=0.4.1 <0.5.0",
+      "from": "grunt@0.4.5",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "async@>=0.1.22 <0.2.0"
+          "from": "async@0.1.22",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
         },
         "coffee-script": {
           "version": "1.3.3",
-          "from": "coffee-script@>=1.3.3 <1.4.0"
+          "from": "coffee-script@1.3.3",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@>=0.6.2 <0.7.0"
+          "from": "colors@0.6.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
         },
         "dateformat": {
           "version": "1.0.2-1.2.3",
-          "from": "dateformat@1.0.2-1.2.3",
+          "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
         },
         "eventemitter2": {
           "version": "0.4.14",
-          "from": "eventemitter2@>=0.4.13 <0.5.0"
+          "from": "eventemitter2@0.4.14",
+          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
         },
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@>=0.1.2 <0.2.0",
+          "from": "findup-sync@0.1.3",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
-              "from": "glob@>=3.2.9 <3.3.0",
+              "from": "glob@3.2.11",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0"
-                },
                 "minimatch": {
                   "version": "0.3.0",
-                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "from": "minimatch@0.3.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.6.4",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
-                    },
-                    "sigmund": {
-                      "version": "1.0.1",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
                 }
@@ -556,132 +554,120 @@
             },
             "lodash": {
               "version": "2.4.2",
-              "from": "lodash@>=2.4.1 <2.5.0",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
-          "from": "glob@>=3.1.21 <3.2.0",
+          "from": "glob@3.1.21",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "graceful-fs@>=1.2.0 <1.3.0"
+              "from": "graceful-fs@1.2.3",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "inherits@>=1.0.0 <2.0.0"
+              "from": "inherits@1.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
             }
           }
         },
-        "hooker": {
-          "version": "0.2.3",
-          "from": "hooker@>=0.2.3 <0.3.0"
-        },
         "iconv-lite": {
           "version": "0.2.11",
-          "from": "iconv-lite@>=0.2.11 <0.3.0"
+          "from": "iconv-lite@0.2.11"
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@>=0.2.12 <0.3.0",
+          "from": "minimatch@0.2.14",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.6.4",
-              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
-            },
-            "sigmund": {
-              "version": "1.0.1",
-              "from": "sigmund@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
             }
           }
         },
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@>=1.0.10 <1.1.0",
-          "dependencies": {
-            "abbrev": {
-              "version": "1.0.7",
-              "from": "abbrev@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
-            }
-          }
-        },
-        "rimraf": {
-          "version": "2.2.8",
-          "from": "rimraf@>=2.2.8 <2.3.0"
+          "from": "nopt@1.0.10",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
         },
         "lodash": {
           "version": "0.9.2",
-          "from": "lodash@>=0.9.2 <0.10.0"
+          "from": "lodash@0.9.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
         },
         "underscore.string": {
           "version": "2.2.1",
-          "from": "underscore.string@>=2.2.1 <2.3.0"
-        },
-        "which": {
-          "version": "1.0.9",
-          "from": "which@>=1.0.5 <1.1.0",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+          "from": "underscore.string@2.2.1",
+          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
         },
         "js-yaml": {
           "version": "2.0.5",
-          "from": "js-yaml@>=2.0.5 <2.1.0",
+          "from": "js-yaml@2.0.5",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.16",
-              "from": "argparse@>=0.1.11 <0.2.0",
+              "from": "argparse@0.1.16",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.7.0",
-                  "from": "underscore@>=1.7.0 <1.8.0",
+                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
                 },
                 "underscore.string": {
                   "version": "2.4.0",
-                  "from": "underscore.string@>=2.4.0 <2.5.0"
+                  "from": "underscore.string@2.4.0",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@>=1.0.2 <1.1.0"
+              "from": "esprima@1.0.4"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@>=0.1.1 <0.2.0"
+          "from": "exit@0.1.2",
+          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
         },
         "getobject": {
           "version": "0.1.0",
-          "from": "getobject@>=0.1.0 <0.2.0"
+          "from": "getobject@0.1.0",
+          "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
         },
         "grunt-legacy-util": {
           "version": "0.2.0",
-          "from": "grunt-legacy-util@>=0.2.0 <0.3.0"
+          "from": "grunt-legacy-util@0.2.0",
+          "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
         },
         "grunt-legacy-log": {
           "version": "0.1.2",
-          "from": "grunt-legacy-log@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.2.tgz",
           "dependencies": {
             "grunt-legacy-log-utils": {
               "version": "0.1.1",
-              "from": "grunt-legacy-log-utils@>=0.1.1 <0.2.0",
+              "from": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz"
             },
             "lodash": {
               "version": "2.4.2",
-              "from": "lodash@>=2.4.1 <2.5.0",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
             },
             "underscore.string": {
               "version": "2.3.3",
-              "from": "underscore.string@>=2.3.3 <2.4.0"
+              "from": "underscore.string@2.3.3"
             }
           }
         }
@@ -689,123 +675,123 @@
     },
     "grunt-available-tasks": {
       "version": "0.6.1",
-      "from": "grunt-available-tasks@0.6.1",
+      "from": "https://registry.npmjs.org/grunt-available-tasks/-/grunt-available-tasks-0.6.1.tgz",
       "resolved": "https://registry.npmjs.org/grunt-available-tasks/-/grunt-available-tasks-0.6.1.tgz"
     },
     "grunt-composer": {
       "version": "0.4.4",
-      "from": "grunt-composer@0.4.4",
+      "from": "https://registry.npmjs.org/grunt-composer/-/grunt-composer-0.4.4.tgz",
       "resolved": "https://registry.npmjs.org/grunt-composer/-/grunt-composer-0.4.4.tgz"
     },
     "grunt-concurrent": {
       "version": "2.1.0",
-      "from": "grunt-concurrent@>=2.1.0 <3.0.0",
+      "from": "https://registry.npmjs.org/grunt-concurrent/-/grunt-concurrent-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-concurrent/-/grunt-concurrent-2.1.0.tgz"
     },
     "grunt-contrib-clean": {
       "version": "0.7.0",
-      "from": "grunt-contrib-clean@>=0.7.0 <0.8.0",
+      "from": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.7.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.7.0.tgz"
     },
     "grunt-contrib-compass": {
       "version": "1.0.4",
-      "from": "grunt-contrib-compass@1.0.4",
+      "from": "https://registry.npmjs.org/grunt-contrib-compass/-/grunt-contrib-compass-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/grunt-contrib-compass/-/grunt-contrib-compass-1.0.4.tgz",
       "dependencies": {
         "async": {
           "version": "0.9.2",
-          "from": "async@>=0.9.0 <0.10.0",
+          "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
         }
       }
     },
     "grunt-contrib-compress": {
       "version": "0.14.0",
-      "from": "grunt-contrib-compress@0.14.0",
+      "from": "https://registry.npmjs.org/grunt-contrib-compress/-/grunt-contrib-compress-0.14.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-contrib-compress/-/grunt-contrib-compress-0.14.0.tgz"
     },
     "grunt-contrib-copy": {
       "version": "0.8.2",
-      "from": "grunt-contrib-copy@0.8.2",
+      "from": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.8.2.tgz",
       "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.8.2.tgz"
     },
     "grunt-contrib-symlink": {
       "version": "0.3.0",
-      "from": "grunt-contrib-symlink@0.3.0",
+      "from": "https://registry.npmjs.org/grunt-contrib-symlink/-/grunt-contrib-symlink-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-contrib-symlink/-/grunt-contrib-symlink-0.3.0.tgz"
     },
     "grunt-contrib-watch": {
       "version": "0.6.1",
-      "from": "grunt-contrib-watch@0.6.1",
+      "from": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.6.1.tgz",
       "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-0.6.1.tgz",
       "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "from": "async@>=0.2.9 <0.3.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-        },
         "lodash": {
           "version": "2.4.2",
-          "from": "lodash@>=2.4.1 <2.5.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+        },
+        "async": {
+          "version": "0.2.10",
+          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         }
       }
     },
     "grunt-drush": {
       "version": "0.0.7",
-      "from": "grunt-drush@0.0.7",
+      "from": "https://registry.npmjs.org/grunt-drush/-/grunt-drush-0.0.7.tgz",
       "resolved": "https://registry.npmjs.org/grunt-drush/-/grunt-drush-0.0.7.tgz",
       "dependencies": {
         "async": {
           "version": "0.9.2",
-          "from": "async@>=0.9.0 <0.10.0",
+          "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
         },
         "lodash": {
           "version": "2.4.2",
-          "from": "lodash@>=2.4.1 <3.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
         }
       }
     },
     "grunt-eslint": {
       "version": "17.3.1",
-      "from": "grunt-eslint@17.3.1",
+      "from": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-17.3.1.tgz",
       "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-17.3.1.tgz"
     },
     "grunt-force-task": {
       "version": "1.0.0",
-      "from": "grunt-force-task@1.0.0",
+      "from": "https://registry.npmjs.org/grunt-force-task/-/grunt-force-task-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-force-task/-/grunt-force-task-1.0.0.tgz"
     },
     "grunt-githooks": {
       "version": "0.5.0",
-      "from": "grunt-githooks@>=0.5.0 <0.6.0",
+      "from": "https://registry.npmjs.org/grunt-githooks/-/grunt-githooks-0.5.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-githooks/-/grunt-githooks-0.5.0.tgz",
       "dependencies": {
         "handlebars": {
           "version": "1.0.12",
-          "from": "handlebars@>=1.0.12 <1.1.0",
+          "from": "https://registry.npmjs.org/handlebars/-/handlebars-1.0.12.tgz",
           "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.0.12.tgz",
           "dependencies": {
             "optimist": {
               "version": "0.3.7",
-              "from": "optimist@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz"
             },
             "uglify-js": {
               "version": "2.3.6",
-              "from": "uglify-js@>=2.3.0 <2.4.0",
+              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@>=0.2.6 <0.3.0",
+                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "source-map": {
                   "version": "0.1.43",
-                  "from": "source-map@>=0.1.7 <0.2.0",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
                 }
               }
@@ -816,27 +802,23 @@
     },
     "grunt-log-headers": {
       "version": "1.0.1",
-      "from": "grunt-log-headers@1.0.1",
+      "from": "https://registry.npmjs.org/grunt-log-headers/-/grunt-log-headers-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/grunt-log-headers/-/grunt-log-headers-1.0.1.tgz"
     },
     "grunt-mkdir": {
       "version": "0.1.2",
-      "from": "grunt-mkdir@0.1.2",
+      "from": "https://registry.npmjs.org/grunt-mkdir/-/grunt-mkdir-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/grunt-mkdir/-/grunt-mkdir-0.1.2.tgz"
     },
     "grunt-newer": {
       "version": "1.1.1",
-      "from": "grunt-newer@1.1.1",
+      "from": "https://registry.npmjs.org/grunt-newer/-/grunt-newer-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/grunt-newer/-/grunt-newer-1.1.1.tgz",
       "dependencies": {
         "async": {
           "version": "0.9.0",
-          "from": "async@0.9.0",
+          "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
-        },
-        "rimraf": {
-          "version": "2.2.8",
-          "from": "rimraf@2.2.8"
         }
       }
     },
@@ -854,17 +836,17 @@
     },
     "grunt-parallel-behat": {
       "version": "0.3.6",
-      "from": "grunt-parallel-behat@0.3.6",
+      "from": "https://registry.npmjs.org/grunt-parallel-behat/-/grunt-parallel-behat-0.3.6.tgz",
       "resolved": "https://registry.npmjs.org/grunt-parallel-behat/-/grunt-parallel-behat-0.3.6.tgz",
       "dependencies": {
         "glob": {
           "version": "3.2.11",
-          "from": "glob@>=3.2.0 <3.3.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz"
         },
         "minimatch": {
           "version": "0.3.0",
-          "from": "minimatch@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz"
         }
       }
@@ -876,875 +858,894 @@
     },
     "grunt-phplint": {
       "version": "0.0.8",
-      "from": "grunt-phplint@>=0.0.8 <0.1.0",
+      "from": "https://registry.npmjs.org/grunt-phplint/-/grunt-phplint-0.0.8.tgz",
       "resolved": "https://registry.npmjs.org/grunt-phplint/-/grunt-phplint-0.0.8.tgz"
     },
     "grunt-phpmd": {
       "version": "0.1.1",
-      "from": "grunt-phpmd@0.1.1",
+      "from": "https://registry.npmjs.org/grunt-phpmd/-/grunt-phpmd-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/grunt-phpmd/-/grunt-phpmd-0.1.1.tgz"
+    },
+    "grunt-rsync": {
+      "version": "1.0.1",
+      "from": "grunt-rsync@1.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-rsync/-/grunt-rsync-1.0.1.tgz",
+      "dependencies": {
+        "rsyncwrapper": {
+          "version": "1.0.0",
+          "from": "rsyncwrapper@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/rsyncwrapper/-/rsyncwrapper-1.0.0.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            }
+          }
+        }
+      }
     },
     "grunt-shell": {
       "version": "1.1.2",
-      "from": "grunt-shell@1.1.2",
+      "from": "https://registry.npmjs.org/grunt-shell/-/grunt-shell-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/grunt-shell/-/grunt-shell-1.1.2.tgz"
     },
     "grunt-staged": {
       "version": "0.1.0",
-      "from": "grunt-staged@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/grunt-staged/-/grunt-staged-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-staged/-/grunt-staged-0.1.0.tgz"
     },
     "handlebars": {
       "version": "4.0.4",
-      "from": "handlebars@>=4.0.0 <5.0.0",
+      "from": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.4.tgz",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.4.tgz"
     },
     "has-ansi": {
       "version": "2.0.0",
-      "from": "has-ansi@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
     },
     "hooker": {
       "version": "0.2.3",
-      "from": "hooker@>=0.2.3 <0.3.0",
+      "from": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
     },
     "hosted-git-info": {
       "version": "2.1.4",
-      "from": "hosted-git-info@>=2.1.4 <3.0.0",
+      "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
     },
     "indent-string": {
       "version": "2.1.0",
-      "from": "indent-string@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz"
     },
     "inflight": {
       "version": "1.0.4",
-      "from": "inflight@>=1.0.4 <2.0.0",
+      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz"
     },
     "inherits": {
       "version": "2.0.1",
-      "from": "inherits@>=2.0.1 <2.1.0",
+      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
     },
     "inquirer": {
       "version": "0.11.0",
-      "from": "inquirer@>=0.11.0 <0.12.0",
+      "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.11.0.tgz",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.11.0.tgz"
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "from": "is-arrayish@>=0.2.1 <0.3.0",
+      "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "from": "is-builtin-module@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
     },
     "is-finite": {
       "version": "1.0.1",
-      "from": "is-finite@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
-      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
     },
     "is-my-json-valid": {
       "version": "2.12.3",
-      "from": "is-my-json-valid@>=2.10.0 <3.0.0",
+      "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz"
     },
     "is-path-cwd": {
       "version": "1.0.0",
-      "from": "is-path-cwd@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
     },
     "is-path-in-cwd": {
       "version": "1.0.0",
-      "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz"
     },
     "is-path-inside": {
       "version": "1.0.0",
-      "from": "is-path-inside@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
     },
     "is-property": {
       "version": "1.0.2",
-      "from": "is-property@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
     },
     "is-resolvable": {
       "version": "1.0.0",
-      "from": "is-resolvable@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz"
     },
     "is-utf8": {
       "version": "0.2.0",
-      "from": "is-utf8@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
     },
     "isarray": {
       "version": "0.0.1",
-      "from": "isarray@0.0.1",
+      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
     },
     "js-yaml": {
       "version": "3.4.3",
-      "from": "js-yaml@>=3.2.5 <4.0.0",
+      "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.3.tgz",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.3.tgz",
       "dependencies": {
         "esprima": {
           "version": "2.7.0",
-          "from": "esprima@>=2.6.0 <3.0.0",
+          "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.0.tgz",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.0.tgz"
         }
       }
     },
     "json-stable-stringify": {
       "version": "1.0.0",
-      "from": "json-stable-stringify@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.0.tgz"
     },
     "jsonify": {
       "version": "0.0.0",
-      "from": "jsonify@>=0.0.0 <0.1.0",
+      "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
     },
     "jsonpointer": {
       "version": "2.0.0",
-      "from": "jsonpointer@2.0.0",
+      "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
     },
     "lazystream": {
       "version": "0.1.0",
-      "from": "lazystream@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
       "dependencies": {
         "readable-stream": {
           "version": "1.0.33",
-          "from": "readable-stream@>=1.0.2 <1.1.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
         }
       }
     },
     "levn": {
       "version": "0.2.5",
-      "from": "levn@>=0.2.5 <0.3.0",
+      "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
     },
     "load-json-file": {
       "version": "1.0.1",
-      "from": "load-json-file@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.0.1.tgz"
     },
     "lodash": {
       "version": "3.10.1",
-      "from": "lodash@3.10.1",
+      "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
     },
     "lodash._arraycopy": {
       "version": "3.0.0",
-      "from": "lodash._arraycopy@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
     },
     "lodash._arrayeach": {
       "version": "3.0.0",
-      "from": "lodash._arrayeach@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
     },
     "lodash._arraymap": {
       "version": "3.0.0",
-      "from": "lodash._arraymap@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz"
     },
     "lodash._baseassign": {
       "version": "3.2.0",
-      "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz"
     },
     "lodash._baseclone": {
       "version": "3.3.0",
-      "from": "lodash._baseclone@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz"
     },
     "lodash._basecopy": {
       "version": "3.0.1",
-      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
     },
     "lodash._basedifference": {
       "version": "3.0.3",
-      "from": "lodash._basedifference@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
       "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz"
     },
     "lodash._baseflatten": {
       "version": "3.1.4",
-      "from": "lodash._baseflatten@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
       "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz"
     },
     "lodash._basefor": {
       "version": "3.0.2",
-      "from": "lodash._basefor@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz",
       "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
     },
     "lodash._baseindexof": {
       "version": "3.1.0",
-      "from": "lodash._baseindexof@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz"
     },
     "lodash._bindcallback": {
       "version": "3.0.1",
-      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
     },
     "lodash._cacheindexof": {
       "version": "3.0.2",
-      "from": "lodash._cacheindexof@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
       "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz"
     },
     "lodash._createassigner": {
       "version": "3.1.1",
-      "from": "lodash._createassigner@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz"
     },
     "lodash._createcache": {
       "version": "3.1.2",
-      "from": "lodash._createcache@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
       "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz"
     },
     "lodash._getnative": {
       "version": "3.9.1",
-      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
-      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
     },
     "lodash._pickbyarray": {
       "version": "3.0.2",
-      "from": "lodash._pickbyarray@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz",
       "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz"
     },
     "lodash._pickbycallback": {
       "version": "3.0.0",
-      "from": "lodash._pickbycallback@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz"
     },
     "lodash.clonedeep": {
       "version": "3.0.2",
-      "from": "lodash.clonedeep@>=3.0.1 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz"
     },
     "lodash.isarguments": {
       "version": "3.0.4",
-      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
     },
     "lodash.isarray": {
       "version": "3.0.4",
-      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
     },
     "lodash.isplainobject": {
       "version": "3.2.0",
-      "from": "lodash.isplainobject@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz"
     },
     "lodash.istypedarray": {
       "version": "3.0.2",
-      "from": "lodash.istypedarray@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.2.tgz",
       "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.2.tgz"
     },
     "lodash.keys": {
       "version": "3.1.2",
-      "from": "lodash.keys@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
     },
     "lodash.keysin": {
       "version": "3.0.8",
-      "from": "lodash.keysin@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
       "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz"
     },
     "lodash.merge": {
       "version": "3.3.2",
-      "from": "lodash.merge@>=3.3.2 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz"
     },
     "lodash.omit": {
       "version": "3.1.0",
-      "from": "lodash.omit@>=3.1.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz"
     },
     "lodash.restparam": {
       "version": "3.6.1",
-      "from": "lodash.restparam@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
     },
     "lodash.toplainobject": {
       "version": "3.0.0",
-      "from": "lodash.toplainobject@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz"
     },
     "loud-rejection": {
       "version": "1.0.0",
-      "from": "loud-rejection@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.0.0.tgz"
     },
     "lru-cache": {
       "version": "2.7.0",
-      "from": "lru-cache@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
     },
     "map-obj": {
       "version": "1.0.1",
-      "from": "map-obj@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
     },
     "meow": {
       "version": "3.5.0",
-      "from": "meow@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/meow/-/meow-3.5.0.tgz",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.5.0.tgz"
     },
     "minimatch": {
       "version": "3.0.0",
-      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz"
     },
     "minimist": {
       "version": "1.2.0",
-      "from": "minimist@>=1.1.3 <2.0.0",
+      "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
     },
     "mkdirp": {
       "version": "0.5.1",
-      "from": "mkdirp@>=0.5.0 <0.6.0",
+      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "from": "minimist@0.0.8",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
         }
       }
     },
     "ms": {
       "version": "0.7.1",
-      "from": "ms@0.7.1",
+      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
     },
     "mute-stream": {
       "version": "0.0.5",
-      "from": "mute-stream@0.0.5",
+      "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
     },
     "node-int64": {
       "version": "0.4.0",
-      "from": "node-int64@>=0.4.0 <0.5.0",
+      "from": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz"
     },
     "nopt": {
       "version": "2.0.0",
-      "from": "nopt@>=2.0.0 <2.1.0",
+      "from": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz"
     },
     "noptify": {
       "version": "0.0.3",
-      "from": "noptify@>=0.0.3 <0.1.0",
+      "from": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz",
       "resolved": "https://registry.npmjs.org/noptify/-/noptify-0.0.3.tgz"
     },
     "normalize-package-data": {
       "version": "2.3.5",
-      "from": "normalize-package-data@>=2.3.4 <3.0.0",
+      "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
     },
     "number-is-nan": {
       "version": "1.0.0",
-      "from": "number-is-nan@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
     },
     "object-assign": {
       "version": "4.0.1",
-      "from": "object-assign@>=4.0.1 <5.0.0",
+      "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
     },
     "once": {
       "version": "1.3.2",
-      "from": "once@>=1.3.0 <1.4.0",
+      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz"
     },
     "onetime": {
       "version": "1.0.0",
-      "from": "onetime@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
     },
     "optimist": {
       "version": "0.6.1",
-      "from": "optimist@>=0.6.1 <0.7.0",
+      "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "from": "minimist@>=0.0.1 <0.1.0",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
         }
       }
     },
     "optionator": {
       "version": "0.6.0",
-      "from": "optionator@>=0.6.0 <0.7.0",
+      "from": "https://registry.npmjs.org/optionator/-/optionator-0.6.0.tgz",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.6.0.tgz"
     },
     "os-homedir": {
       "version": "1.0.1",
-      "from": "os-homedir@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
     },
     "pad-stream": {
       "version": "1.2.0",
-      "from": "pad-stream@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/pad-stream/-/pad-stream-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/pad-stream/-/pad-stream-1.2.0.tgz"
     },
     "parse-json": {
       "version": "2.2.0",
-      "from": "parse-json@>=2.2.0 <3.0.0",
+      "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
     },
     "parse-ms": {
       "version": "1.0.0",
-      "from": "parse-ms@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.0.tgz"
     },
     "path-exists": {
       "version": "2.0.0",
-      "from": "path-exists@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.0.0.tgz"
     },
     "path-is-absolute": {
       "version": "1.0.0",
-      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
     },
     "path-is-inside": {
       "version": "1.0.1",
-      "from": "path-is-inside@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
     },
     "path-type": {
       "version": "1.0.0",
-      "from": "path-type@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/path-type/-/path-type-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.0.0.tgz"
     },
     "pify": {
       "version": "2.3.0",
-      "from": "pify@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
     },
     "pinkie": {
       "version": "1.0.0",
-      "from": "pinkie@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-1.0.0.tgz"
     },
     "pinkie-promise": {
       "version": "1.0.0",
-      "from": "pinkie-promise@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-1.0.0.tgz"
     },
     "plur": {
       "version": "1.0.0",
-      "from": "plur@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz"
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "from": "prelude-ls@>=1.1.1 <1.2.0",
+      "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
     },
     "pretty-bytes": {
       "version": "2.0.1",
-      "from": "pretty-bytes@>=2.0.1 <3.0.0",
+      "from": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-2.0.1.tgz"
     },
     "pretty-ms": {
       "version": "2.1.0",
-      "from": "pretty-ms@>=2.1.0 <3.0.0",
+      "from": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz"
     },
     "process-nextick-args": {
       "version": "1.0.3",
-      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
     },
     "pump": {
       "version": "1.0.1",
-      "from": "pump@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/pump/-/pump-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.1.tgz",
       "dependencies": {
         "end-of-stream": {
           "version": "1.1.0",
-          "from": "end-of-stream@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz"
         }
       }
     },
     "pumpify": {
       "version": "1.3.3",
-      "from": "pumpify@>=1.3.3 <2.0.0",
+      "from": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.3.tgz",
       "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.3.tgz"
     },
     "qs": {
       "version": "0.5.6",
-      "from": "qs@>=0.5.2 <0.6.0",
+      "from": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz",
       "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
     },
     "read-json-sync": {
       "version": "1.1.0",
-      "from": "read-json-sync@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.0.tgz",
       "dependencies": {
         "graceful-fs": {
           "version": "3.0.8",
-          "from": "graceful-fs@>=3.0.5 <4.0.0",
+          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
         }
       }
     },
     "read-pkg": {
       "version": "1.1.0",
-      "from": "read-pkg@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
     },
     "read-pkg-up": {
       "version": "1.0.1",
-      "from": "read-pkg-up@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
     },
     "readable-stream": {
       "version": "2.0.4",
-      "from": "readable-stream@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz"
     },
     "readline2": {
       "version": "1.0.1",
-      "from": "readline2@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz"
     },
     "redent": {
       "version": "1.0.0",
-      "from": "redent@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz"
     },
     "repeating": {
       "version": "2.0.0",
-      "from": "repeating@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz"
     },
     "restore-cursor": {
       "version": "1.0.1",
-      "from": "restore-cursor@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
     },
     "rimraf": {
       "version": "2.2.8",
-      "from": "rimraf@>=2.2.1 <2.3.0",
+      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
     },
     "run-async": {
       "version": "0.1.0",
-      "from": "run-async@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz"
     },
     "rx-lite": {
       "version": "3.1.2",
-      "from": "rx-lite@>=3.1.2 <4.0.0",
+      "from": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
     },
     "semver": {
       "version": "5.0.3",
-      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+      "from": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
     },
     "semver-regex": {
       "version": "1.0.0",
-      "from": "semver-regex@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz"
     },
     "semver-truncate": {
       "version": "1.0.0",
-      "from": "semver-truncate@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.0.0.tgz",
       "dependencies": {
         "semver": {
           "version": "4.3.6",
-          "from": "semver@>=4.0.3 <5.0.0",
+          "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         }
       }
     },
     "shelljs": {
       "version": "0.2.6",
-      "from": "shelljs@>=0.2.6 <0.3.0",
+      "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.2.6.tgz",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.2.6.tgz"
     },
     "sigmund": {
       "version": "1.0.1",
-      "from": "sigmund@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
     },
     "source-map": {
       "version": "0.4.4",
-      "from": "source-map@>=0.4.4 <0.5.0",
+      "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
     },
     "spdx-correct": {
       "version": "1.0.2",
-      "from": "spdx-correct@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
     },
     "spdx-exceptions": {
       "version": "1.0.4",
-      "from": "spdx-exceptions@>=1.0.4 <2.0.0",
+      "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
     },
     "spdx-expression-parse": {
       "version": "1.0.1",
-      "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.1.tgz"
     },
     "spdx-license-ids": {
       "version": "1.1.0",
-      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+      "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
     },
     "split2": {
       "version": "1.0.0",
-      "from": "split2@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz"
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "from": "sprintf-js@>=1.0.2 <1.1.0",
+      "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
     },
     "stack-parser": {
       "version": "0.0.1",
-      "from": "stack-parser@>=0.0.1 <0.1.0",
+      "from": "https://registry.npmjs.org/stack-parser/-/stack-parser-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/stack-parser/-/stack-parser-0.0.1.tgz"
     },
     "staged-git-files": {
       "version": "0.0.4",
-      "from": "staged-git-files@0.0.4",
+      "from": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-0.0.4.tgz",
       "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-0.0.4.tgz"
     },
     "string_decoder": {
       "version": "0.10.31",
-      "from": "string_decoder@>=0.10.0 <0.11.0",
+      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
     },
     "strip-ansi": {
       "version": "3.0.0",
-      "from": "strip-ansi@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
     },
     "strip-bom": {
       "version": "2.0.0",
-      "from": "strip-bom@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
     },
     "strip-indent": {
       "version": "1.0.1",
-      "from": "strip-indent@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
     },
     "strip-json-comments": {
       "version": "1.0.4",
-      "from": "strip-json-comments@>=1.0.1 <1.1.0",
+      "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
     },
     "supports-color": {
       "version": "2.0.0",
-      "from": "supports-color@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
     },
     "tar-stream": {
       "version": "1.2.2",
-      "from": "tar-stream@>=1.2.1 <1.3.0",
+      "from": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.2.2.tgz",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.2.2.tgz"
     },
     "text-table": {
       "version": "0.2.0",
-      "from": "text-table@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
     },
     "through": {
       "version": "2.3.8",
-      "from": "through@>=2.3.6 <3.0.0",
+      "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
     "through2": {
       "version": "2.0.0",
-      "from": "through2@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz"
     },
     "time-grunt": {
       "version": "1.3.0",
-      "from": "time-grunt@1.3.0",
+      "from": "https://registry.npmjs.org/time-grunt/-/time-grunt-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/time-grunt/-/time-grunt-1.3.0.tgz"
     },
     "tiny-lr-fork": {
       "version": "0.0.5",
-      "from": "tiny-lr-fork@0.0.5",
+      "from": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz",
       "resolved": "https://registry.npmjs.org/tiny-lr-fork/-/tiny-lr-fork-0.0.5.tgz"
     },
     "tmp": {
       "version": "0.0.24",
-      "from": "tmp@0.0.24",
+      "from": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz"
     },
     "to-double-quotes": {
       "version": "2.0.0",
-      "from": "to-double-quotes@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/to-double-quotes/-/to-double-quotes-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/to-double-quotes/-/to-double-quotes-2.0.0.tgz"
     },
     "to-single-quotes": {
       "version": "2.0.0",
-      "from": "to-single-quotes@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/to-single-quotes/-/to-single-quotes-2.0.0.tgz"
     },
     "trim-newlines": {
       "version": "1.0.0",
-      "from": "trim-newlines@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
     },
     "tryit": {
       "version": "1.0.2",
-      "from": "tryit@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/tryit/-/tryit-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.2.tgz"
     },
     "type-check": {
       "version": "0.3.1",
-      "from": "type-check@>=0.3.1 <0.4.0",
+      "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
     },
     "typedarray": {
       "version": "0.0.6",
-      "from": "typedarray@>=0.0.5 <0.1.0",
+      "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
     },
     "uglify-js": {
       "version": "2.4.24",
-      "from": "uglify-js@>=2.4.0 <2.5.0",
+      "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "from": "async@>=0.2.6 <0.3.0",
+          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
         },
         "source-map": {
           "version": "0.1.34",
-          "from": "source-map@0.1.34",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz"
         }
       }
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
-      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
     },
     "underscore": {
       "version": "1.4.4",
-      "from": "underscore@>=1.4.0 <1.5.0",
+      "from": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
     },
     "underscore.string": {
       "version": "3.2.2",
-      "from": "underscore.string@>=3.2.2 <4.0.0",
+      "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.2.tgz",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.2.tgz"
     },
     "user-home": {
       "version": "2.0.0",
-      "from": "user-home@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz"
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "from": "util-deprecate@>=1.0.1 <1.1.0",
+      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
-      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+      "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
     },
     "which": {
       "version": "1.0.9",
-      "from": "which@>=1.0.5 <1.1.0",
+      "from": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
       "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
     },
     "win-spawn": {
       "version": "2.0.0",
-      "from": "win-spawn@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/win-spawn/-/win-spawn-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/win-spawn/-/win-spawn-2.0.0.tgz"
     },
     "window-size": {
       "version": "0.1.0",
-      "from": "window-size@0.1.0",
+      "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
     },
     "wordwrap": {
       "version": "0.0.3",
-      "from": "wordwrap@>=0.0.2 <0.1.0",
+      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
     },
     "wrappy": {
       "version": "1.0.1",
-      "from": "wrappy@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
     },
     "write": {
       "version": "0.2.1",
-      "from": "write@>=0.2.1 <0.3.0",
+      "from": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
     },
     "xml-escape": {
       "version": "1.0.0",
-      "from": "xml-escape@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@>=4.0.0 <4.1.0",
+      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     },
     "yargs": {
       "version": "3.5.4",
-      "from": "yargs@>=3.5.4 <3.6.0",
+      "from": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
       "dependencies": {
         "wordwrap": {
           "version": "0.0.2",
-          "from": "wordwrap@0.0.2",
+          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
         }
       }
     },
     "zip-stream": {
       "version": "0.6.0",
-      "from": "zip-stream@>=0.6.0 <0.7.0",
+      "from": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.6.0.tgz",
       "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.6.0.tgz",
       "dependencies": {
         "readable-stream": {
           "version": "1.0.33",
-          "from": "readable-stream@>=1.0.26 <1.1.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz"
         }
       }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "grunt-phpcs": "git+https://github.com/grayside/grunt-phpcs.git#0.5.0-fork2",
     "grunt-phplint": "~0.0.8",
     "grunt-phpmd": "~0.1.1",
+    "grunt-rsync": "^1.0.1",
     "grunt-shell": "^1.1.2",
     "grunt-staged": "~0.1.0",
     "lodash": "^3.10.1",

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -54,11 +54,13 @@ module.exports = function(grunt) {
   });
 
   // rsync-based alternative to copy:tempbuild.
-  grunt.config('rsync.tempbuild.options', {
-    args: [
-      '-ahW',
-      '--stats'
-    ],
+  grunt.config('rsync.tempbuild', {
+    'options', {
+      args: [
+        '-ahW',
+        '--stats'
+      ],
+    },
     src: '<%= config.buildPaths.temp %>/',
     dest: '<%= config.buildPaths.html %>'
   });

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -5,6 +5,8 @@ module.exports = function(grunt) {
    *
    * grunt copy:static
    *   Copies all files from src/static to the build/html directory.
+   * grunt rsync:tempbuild
+   *   Duplicate Drupal docroot from temporary location to the final build target.
    */
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.config('copy.static', {
@@ -47,5 +49,15 @@ module.exports = function(grunt) {
         dest: '<%= config.srcPaths.drupal %>/sites/default'
       }
     ]
+  });
+
+  // rsync-based alternative to copy:tempbuild.
+  grunt.config('rsync.tempbuild.options', {
+    args: [
+      '-ahW',
+      '--stats'
+    ],
+    src: '<%= config.buildPaths.temp %>/',
+    dest: '<%= config.buildPaths.html %>'
   });
 };

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -7,6 +7,11 @@ module.exports = function(grunt) {
    *   Copies all files from src/static to the build/html directory.
    * grunt rsync:tempbuild
    *   Duplicate Drupal docroot from temporary location to the final build target.
+   * grunt copy:tempbuild
+   *   Original implementation of rsync:tempbuild, preserved for backwards
+   *   compatibility and Windows support.
+   * grunt copy:defaults
+   *   Copies Drupal's sites/default directory into the custom codebase.
    */
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-rsync');
@@ -25,6 +30,7 @@ module.exports = function(grunt) {
       }
     ]
   });
+
   grunt.config('copy.tempbuild', {
     options: {
       mode: true
@@ -39,6 +45,18 @@ module.exports = function(grunt) {
       }
     ]
   });
+
+  grunt.config('rsync.tempbuild', {
+    options: {
+      args: [
+        '-ahW',
+        '--stats'
+      ]
+    },
+    src: '<%= config.buildPaths.temp %>/',
+    dest: '<%= config.buildPaths.html %>'
+  });
+
   grunt.config('copy.defaults', {
     options: {
       mode: true
@@ -53,15 +71,4 @@ module.exports = function(grunt) {
     ]
   });
 
-  // rsync-based alternative to copy:tempbuild.
-  grunt.config('rsync.tempbuild', {
-    'options', {
-      args: [
-        '-ahW',
-        '--stats'
-      ],
-    },
-    src: '<%= config.buildPaths.temp %>/',
-    dest: '<%= config.buildPaths.html %>'
-  });
 };

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -51,7 +51,7 @@ module.exports = function(grunt) {
       args: [
         '-ahW',
         '--stats'
-      ]
+      ],
       src: '<%= config.buildPaths.temp %>/',
       dest: '<%= config.buildPaths.html %>'
     },

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -9,6 +9,8 @@ module.exports = function(grunt) {
    *   Duplicate Drupal docroot from temporary location to the final build target.
    */
   grunt.loadNpmTasks('grunt-contrib-copy');
+  grunt.loadNpmTasks('grunt-rsync');
+
   grunt.config('copy.static', {
     options: {
       mode: true

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -52,9 +52,9 @@ module.exports = function(grunt) {
         '-ahW',
         '--stats'
       ]
+      src: '<%= config.buildPaths.temp %>/',
+      dest: '<%= config.buildPaths.html %>'
     },
-    src: '<%= config.buildPaths.temp %>/',
-    dest: '<%= config.buildPaths.html %>'
   });
 
   grunt.config('copy.defaults', {

--- a/tasks/make.js
+++ b/tasks/make.js
@@ -57,7 +57,7 @@ module.exports = function(grunt) {
         'clean:temp',
         'drush:make',
         'clean:default',
-        gdt.canRsync ? 'rsync.tempbuild' : 'copy:tempbuild',
+        gdt.canRsync ? 'rsync:tempbuild' : 'copy:tempbuild',
         'clean:temp'
       ]
     }

--- a/tasks/make.js
+++ b/tasks/make.js
@@ -10,7 +10,8 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-newer');
 
   var Help = require('../lib/help')(grunt),
-    Drupal = require('../lib/drupal')(grunt);
+    Drupal = require('../lib/drupal')(grunt),
+    gdt = require('../lib/util');
 
   var path = require('path'),
     _ = require('lodash');
@@ -39,7 +40,7 @@ module.exports = function(grunt) {
   });
 
   grunt.registerTask('drushmake', 'Prepare the build directory and run "drush make"', function() {
-    grunt.task.run('mkdir:init', 'clean:temp', 'drush:make', 'clean:default', 'copy:tempbuild', 'clean:temp');
+    grunt.task.run(this.options().tasks);
   });
 
   // The "drushmake" task will run make only if the src file specified here is
@@ -48,7 +49,17 @@ module.exports = function(grunt) {
   grunt.config('drushmake', {
     default: {
       src: ['<%= config.srcPaths.make %>', '<%= config.srcPaths.drupal %>/**/*.make'],
-      dest: '<%= config.buildPaths.html %>'
+      dest: '<%= config.buildPaths.html %>',
+    },
+    options: {
+      tasks: [
+        'mkdir:init',
+        'clean:temp',
+        'drush:make',
+        'clean:default',
+        gdt.canRsync ? 'rsync.tempbuild' : 'copy:tempbuild',
+        'clean:temp'
+      ]
     }
   });
 


### PR DESCRIPTION
Picking up from https://github.com/phase2/grunt-drupal-tasks/pull/235.

This change preserves copy:tempbuild, uses it on Windows, and on non-Windows environments switches to rsync. I thought about fancier rsync detection, but came to the conclusion I couldn't effectively test the detection mechanism itself.

As part of making this logic, I moved the configuration of drushmake build steps into the global config for our "drushmake" task. This means any use of `grunt.config.set('drushmake.options.tasks', {})` can overwrite the build process, a bit more flexible than the current requirement in bouncing around the registered drushmake task.