### PR TITLE
Drop support for PHP 5.4 due to emerging Drush incompatibility.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: php
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7
@@ -25,10 +24,6 @@ matrix:
     - php: 7
       env: NVM_NODE_VERSION="node" GDT_DRUPAL_CORE="8" GDT_TEST_URL="http://127.0.0.1:8080/core/misc/drupal.js" CXX=g++-4.8
   exclude:
-    - php: 5.4
-      env: NVM_NODE_VERSION="4.3" GDT_DRUPAL_CORE="8" GDT_TEST_URL="http://127.0.0.1:8080/core/misc/drupal.js" CXX=g++-4.8
-    - php: 5.4
-      env: NVM_NODE_VERSION="node" GDT_DRUPAL_CORE="8" GDT_TEST_URL="http://127.0.0.1:8080/core/misc/drupal.js" CXX=g++-4.8
     - php: 7
       env: NVM_NODE_VERSION="0.12" GDT_DRUPAL_CORE="7" GDT_TEST_URL="http://127.0.0.1:8080/misc/drupal.js" CXX=g++-4.8
 before_install:


### PR DESCRIPTION
Per a Drush error on recent test runs, PHP 5.4 support is being dropped from Drush. This PR pulls it from travis testing by way of dropping it in GDT as well. If we do not feel PHP 5.4 support can be let go, we should instead identify what version of Drush will be safe to use and plan to pin that in composer.json.

See also #259 

@jhedstrom 