### PR TITLE
Remove theme validate from validate:staged.

### DIFF
--- a/tasks/quality.js
+++ b/tasks/quality.js
@@ -205,7 +205,11 @@ module.exports = function(grunt) {
       grunt.loadNpmTasks('grunt-' + mode);
       // Wrap each task configured for validate in the newer command.
       // grunt-phplint already contains complex caching that does the same thing.
-      validate = validate.map(function(item) { return item != 'phplint:all' ? mode + ':' + item : item; });
+      validate = validate.filter(function(item) {
+        return item.indexOf('themes:') !== 0;
+      }).map(function(item) {
+        return item != 'phplint:all' ? mode + ':' + item : item;
+      });
     }
 
     if (validate.length) {


### PR DESCRIPTION
`grunt validate:staged`, which is used by the githooks system, chokes if a theme is configured because there's nothing that can be done with `staged:themes:<name>:validate`.

This change causes tasks that are prefixed `themes:` to be pulled from the `validate:staged` handling.