### PR TITLE
Improve performance and cacheability of composer install.

### DIFF
--- a/tasks/composer.js
+++ b/tasks/composer.js
@@ -11,7 +11,15 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-composer');
     var Help = require('../lib/help')(grunt);
 
-    grunt.config(['composer', 'install'], {});
+    grunt.config(['composer', 'install'], {
+      options: {
+        flags: [
+          'no-interaction',
+          'no-progress',
+          'prefer-dist'
+        ],
+      }
+    });
 
     Help.add({
       task: 'composer',


### PR DESCRIPTION
Optimizes performance for rare dependency changes and CI that cleans the vendor directory. Note the --prefer-dist option means attempting to make more use of release tarballs, in the past this could lead to hitting Github API limits, but in the last couple weeks Github decided to remove those limits for use cases such as composer.

Fixes #253 

@jhedstrom @arithmetric 