### PR TITLE
newer for make: Add support for make.yml file extension.

### DIFF
--- a/tasks/make.js
+++ b/tasks/make.js
@@ -48,7 +48,11 @@ module.exports = function(grunt) {
   // source directory to catch make files included from the primary one.
   grunt.config('drushmake', {
     default: {
-      src: ['<%= config.srcPaths.make %>', '<%= config.srcPaths.drupal %>/**/*.make'],
+      src: [
+        '<%= config.srcPaths.make %>',
+        '<%= config.srcPaths.drupal %>/*.make',
+        '<%= config.srcPaths.drupal %>/*.make.yml'
+      ],
       dest: '<%= config.buildPaths.html %>',
     },
     options: {

--- a/tasks/make.js
+++ b/tasks/make.js
@@ -50,8 +50,7 @@ module.exports = function(grunt) {
     default: {
       src: [
         '<%= config.srcPaths.make %>',
-        '<%= config.srcPaths.drupal %>/*.make',
-        '<%= config.srcPaths.drupal %>/*.make.yml'
+        '<%= config.srcPaths.drupal %>/**/*.{make,make.yml}'
       ],
       dest: '<%= config.buildPaths.html %>',
     },


### PR DESCRIPTION
The existing implementation of newer does not support files that end in .make.yml, which is the current behavior by default for Gadget.
