### PR TITLE
Improve newer for drushmake performance

### DIFF
--- a/tasks/make.js
+++ b/tasks/make.js
@@ -50,7 +50,7 @@ module.exports = function(grunt) {
     default: {
       src: [
         '<%= config.srcPaths.make %>',
-        '<%= config.srcPaths.drupal %>/**/*.{make,make.yml}'
+        '<%= config.srcPaths.drupal %>/*.{make,make.yml}'
       ],
       dest: '<%= config.buildPaths.html %>',
     },

--- a/tasks/make.js
+++ b/tasks/make.js
@@ -48,7 +48,11 @@ module.exports = function(grunt) {
   // source directory to catch make files included from the primary one.
   grunt.config('drushmake', {
     default: {
-      src: ['<%= config.srcPaths.make %>', '<%= config.srcPaths.drupal %>/**/*.make'],
+      src: [
+        '<%= config.srcPaths.make %>',
+        '<%= config.srcPaths.drupal %>/*.make',
+        '<%= config.srcPaths.drupal %>/*.make.yml'
+      ],
       dest: '<%= config.buildPaths.html %>',
     },
     options: {

--- a/tasks/make.js
+++ b/tasks/make.js
@@ -50,8 +50,7 @@ module.exports = function(grunt) {
     default: {
       src: [
         '<%= config.srcPaths.make %>',
-        '<%= config.srcPaths.drupal %>/*.make',
-        '<%= config.srcPaths.drupal %>/*.make.yml'
+        '<%= config.srcPaths.drupal %>/**/*.{make,make.yml}'
       ],
       dest: '<%= config.buildPaths.html %>',
     },


### PR DESCRIPTION
This builds on #272 .

The newer scanner is current recursively checking the entire src directory (if I read this right) looking for makefiles. This likely explains why projects sometimes have a longish pause toward what seems like the end of the validate step.

I have not come across a use case for needing that recursion, and it's pretty easy to customize the makefiles to scan via `grunt.config.set('drushmake.default.src', [ 'alternate paths'])`.

B/C break, so targeting 1.0.