### PR TITLE
Fix packaging with Grunt v1 and G-D-T v0.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,5 +57,6 @@ script:
   - grunt test
   - sleep 1; while (ps aux | grep '[b]ehat' > /dev/null); do sleep 1; done
   - for pid in `ps aux | grep drush | grep runserver | awk '{print $2}'`; do echo "Stopping drush pid $pid"; kill -SIGINT $pid; done;
+  - grunt package --quiet
   - mocha --timeout 10000 node_modules/grunt-drupal-tasks/test/build.js
   - mocha node_modules/grunt-drupal-tasks/test/library.js

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -26,7 +26,8 @@ module.exports = function(grunt) {
         cwd: '<%= config.srcPaths.drupal %>/static',
         src: ['**', '.**'],
         dest: '<%= config.buildPaths.html %>',
-        dot: true
+        dot: true,
+        follow: true
       }
     ]
   });
@@ -41,7 +42,8 @@ module.exports = function(grunt) {
         cwd: '<%= config.buildPaths.temp %>',
         src: ['**', '.**'],
         dest: '<%= config.buildPaths.html %>',
-        dot: true
+        dot: true,
+        follow: true
       }
     ]
   });

--- a/tasks/package.js
+++ b/tasks/package.js
@@ -27,13 +27,15 @@ module.exports = function(grunt) {
           cwd: '<%= config.buildPaths.html %>',
           src: srcFiles,
           dest: destPath + (grunt.config.get('config.packages.dest.docroot') || ''),
-          dot: true
+          dot: true,
+          follow: true
         },
         {
           expand: true,
           src: projFiles,
           dest: destPath + (grunt.config.get('config.packages.dest.devResources') || ''),
-          dot: true
+          dot: true,
+          follow: true
         }
       ],
       options: {

--- a/test/build.js
+++ b/test/build.js
@@ -111,7 +111,7 @@ describe('grunt', function() {
       });
     });
 
-    // Ensure a custom library file is available under build.
+    // Ensure a custom library file is available under package.
     var librariesPackageDest = (drupalCore == '8') ? 'build/packages/package/libraries/example_lib/example.md' : 'build/packages/package/sites/all/libraries/example_lib/example.md';
     it('custom library file should exist in package', function(done) {
       fs.exists(librariesPackageDest, function (exists) {

--- a/test/build.js
+++ b/test/build.js
@@ -84,6 +84,60 @@ describe('grunt', function() {
       });
     });
 
+    // Ensure a custom library file is available under build.
+    var librariesBuildDest = (drupalCore == '8') ? 'build/html/libraries/example_lib/example.md' : 'build/html/sites/all/libraries/example_lib/example.md';
+    it('custom library file should exist in build', function(done) {
+      fs.exists(librariesBuildDest, function (exists) {
+        assert.ok(exists);
+        done();
+      });
+    });
+
+    // Ensure a custom module file is available under build.
+    var modulesBuildDest = (drupalCore == '8') ? 'build/html/modules/custom/test.php' : 'build/html/sites/all/modules/custom/test.php';
+    it('custom module file should exist in build', function(done) {
+      fs.exists(modulesBuildDest, function (exists) {
+        assert.ok(exists);
+        done();
+      });
+    });
+
+    // Ensure a custom theme file is available under build.
+    var themesBuildDest = (drupalCore == '8') ? 'build/html/themes/custom/example_theme/config.rb' : 'build/html/sites/all/themes/custom/example_theme/config.rb';
+    it('custom theme file should exist in build', function(done) {
+      fs.exists(themesBuildDest, function (exists) {
+        assert.ok(exists);
+        done();
+      });
+    });
+
+    // Ensure a custom library file is available under build.
+    var librariesPackageDest = (drupalCore == '8') ? 'build/packages/package/libraries/example_lib/example.md' : 'build/packages/package/sites/all/libraries/example_lib/example.md';
+    it('custom library file should exist in package', function(done) {
+      fs.exists(librariesPackageDest, function (exists) {
+        assert.ok(exists);
+        done();
+      });
+    });
+
+    // Ensure a custom module file is available under package.
+    var modulesPackageDest = (drupalCore == '8') ? 'build/packages/package/modules/custom/test.php' : 'build/packages/package/sites/all/modules/custom/test.php';
+    it('custom module file should exist in package', function(done) {
+      fs.exists(modulesPackageDest, function (exists) {
+        assert.ok(exists);
+        done();
+      });
+    });
+
+    // Ensure a custom theme file is available under package.
+    var themesPackageDest = (drupalCore == '8') ? 'build/packages/package/themes/custom/example_theme/config.rb' : 'build/packages/package/sites/all/themes/custom/example_theme/config.rb';
+    it('custom theme file should exist in package', function(done) {
+      fs.exists(themesPackageDest, function (exists) {
+        assert.ok(exists);
+        done();
+      });
+    });
+
     // Ensure the build/html/sites/all/themes/custom/example_theme/stylesheets/screen.css
     // file exists, which should be created by compass.
     var sassDest = (drupalCore == '8') ? 'build/html/themes/custom/example_theme/stylesheets/screen.css' : 'build/html/sites/all/themes/custom/example_theme/stylesheets/screen.css';

--- a/test/test.sh
+++ b/test/test.sh
@@ -13,6 +13,7 @@ run_tests () {
   grunt test
   sleep 1; while (ps aux | grep '[b]ehat' > /dev/null); do sleep 1; done
   for pid in `ps aux | grep drush | grep runserver | awk '{print $2}'`; do echo "Stopping drush pid $pid"; kill -SIGINT $pid; done;
+  grunt package --quiet
   # end-to-end tests
   mocha --timeout 10000 node_modules/grunt-drupal-tasks/test/build.js
   # unit tests


### PR DESCRIPTION
Adds the `follow: true` option for node-glob to ensure it follows symlinks into directories for relevant copy tasks. This fixes an issue where the output of `grunt package` did not include files targeted by symlinks, like src/modules from sites/all/modules/custom.

Also adds test coverage for the build and package tasks.

Fixes #274.
