### PR TITLE
Add DrupalPractice standard to phpcs analysis.

### DIFF
--- a/tasks/quality.js
+++ b/tasks/quality.js
@@ -54,7 +54,7 @@ module.exports = function(grunt) {
   if (grunt.config.get('config.phpcs')) {
     var phpcs = grunt.config.get('config.phpcs.dir') || phpcsPatterns;
     var phpStandard = grunt.config('config.phpcs.standard')
-      || 'vendor/drupal/coder/coder_sniffer/Drupal';
+      || 'vendor/drupal/coder/coder_sniffer/Drupal,vendor/drupal/coder/coder_sniffer/DrupalPractice';
 
     // Support deprecated config.phpcs.ignoreExitCode value until 1.0.
     var ignoreError = grunt.config('config.validate.ignoreError') || grunt.config('config.phpcs.ignoreExitCode');


### PR DESCRIPTION
This adds the additional set of best practices in the Coder module to our PHPCS processing. Since it can lead to new failures for existing projects, specifically targeting the 1.0 branch.

I have tested that this executes, and runs with both commands, but did not see any warnings from the DrupalPractice scanner to confirm it.