### PR TITLE
Initial take on adding Drupal core composer install for >= 8.1.0

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -54,6 +54,7 @@ module.exports = function(grunt) {
 
   // Wire up the generated docroot to our custom code.
   tasksDefault.push('scaffold');
+  tasksDefault.push('composer-drupal');
 
   if (grunt.config.get(['composer', 'install'])) {
     tasksDefault.unshift('composer:install');

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "grunt-shell": "^1.2.1",
     "grunt-staged": "~0.1.0",
     "lodash": "^4.5.0",
+    "semver": "^5.1.0",
     "time-grunt": "^1.3.0"
   },
   "engines": {

--- a/tasks/composer.js
+++ b/tasks/composer.js
@@ -21,10 +21,38 @@ module.exports = function(grunt) {
       }
     });
 
+    grunt.config(['composer', 'drupal-install'], {
+      options: {
+        flags: [
+          'no-interaction',
+          'no-progress',
+          'prefer-dist'
+        ],
+        cwd: 'build/html'
+      }
+    });
+
     Help.add({
-      task: 'composer',
+      task: 'composer:install',
       group: 'Dependency Management',
-      description: 'Install dependencies defined in this project\'s composer.json file.'
+      description: 'Install development dependencies defined in this project\'s composer.json file.'
     });
   }
+
+  grunt.registerTask('composer-drupal', 'Install Drupal dependencies and update autoloader.', function() {
+    grunt.task.requires('drushmake:default');
+    grunt.task.requires('scaffold');
+
+    var done = this.async();
+    var drupal = require('../lib/drupal')(grunt);
+    drupal.loadDrushStatus(function (err, status) {
+      if (err) {
+        grunt.fail.fatal('Cannot load Drush status for built Drupal docroot.\n\n' + err);
+      }
+      else if (require('semver').gte(status['drupal-version'], '8.1')) {
+        grunt.task.run('composer:drupal-install');
+      }
+      done();
+    });
+  });
 };

--- a/tasks/composer.js
+++ b/tasks/composer.js
@@ -49,7 +49,7 @@ module.exports = function(grunt) {
       if (err) {
         grunt.fail.fatal('Cannot load Drush status for built Drupal docroot.\n\n' + err);
       }
-      else if (require('semver').gte(status['drupal-version'], '8.1')) {
+      else if (require('semver').gte(status['drupal-version'], '8.1.0')) {
         grunt.task.run('composer:drupal-install');
       }
       done();


### PR DESCRIPTION
This PR checks to see if the version of Drupal is >= 8.1, and if so it adds an extra composer:install operation. The theory of the require statements is to make sure it does not operate unless drushmake and scaffold already ran. This ensures the codebase with it's composer.json is already present, and that the custom modules and libraries from the codebase have been symlinked in for any composer autoloader magic.

I suppose an alternative to adding the semver check would be looking for composer.json and !vendor.

The build process is currently incomplete, now that Drupal 8.1 does not ship the vendor directory pre-installed.

@arithmetric @jhedstrom 

Warning: Untested changeset.