### PR TITLE
Pin D8 test assets to use Drush 8.x

### DIFF
--- a/test/test_assets_d8/composer.json
+++ b/test/test_assets_d8/composer.json
@@ -4,7 +4,7 @@
     "require-dev": {
         "behat/mink-zombie-driver": "~1.2",
         "drupal/drupal-extension": "~3.0",
-        "drush/drush": "dev-master",
+        "drush/drush": "^8",
         "phpmd/phpmd": "~2.1",
         "drupal/coder": "^8.2",
         "guzzlehttp/guzzle" : "^6.0@dev",


### PR DESCRIPTION
In #259 we pinned the Drush version in example/composer.json to ^8 to avoid errors in pulling from HEAD of Drush 9. Unfortunately, we previously missed the D8 variant of the composer.json used in the tests.

This [Travis Build](https://travis-ci.org/phase2/grunt-drupal-tasks/jobs/130415676) for #278 demonstrates the issue.

This change will fix test failures for both master and 1.0-pre.

Of secondary note, looks like Drush is switching to use [Robo](https://github.com/Codegyre/Robo), and Travis is running builds with XDEBUG enabled, which [significantly slows down Composer performance](https://getcomposer.org/doc/articles/troubleshooting.md#xdebug-impact-on-composer)