### PR TITLE
Improve performance of drushmake's newer by selectively skipping some…

### DIFF
--- a/tasks/make.js
+++ b/tasks/make.js
@@ -44,13 +44,19 @@ module.exports = function(grunt) {
   });
 
   // The "drushmake" task will run make only if the src file specified here is
-  // newer than the dest file specified. This includes all make files in the
-  // source directory to catch make files included from the primary one.
+  // newer than the dest file specified. This includes scanning recursively into
+  // the source directory for common places included makefiles might be located.
   grunt.config('drushmake', {
     default: {
       src: [
+        // Check the configured makefile.
         '<%= config.srcPaths.make %>',
-        '<%= config.srcPaths.drupal %>/**/*.{make,make.yml}'
+        // Check files at the immediate root of the Drupal source files.
+        '<%= config.srcPaths.drupal %>/*.{make,make.yml}'
+        // Recursively check inside modules, profiles, and libraries.
+        '<%= config.srcPaths.drupal %>/{modules,profiles,libraries}/**/*.{make,make.yml}'
+        // Check at the immediate root of each theme.
+        '<%= config.srcPaths.drupal %>/themes/*/*.{make,make.yml}'
       ],
       dest: '<%= config.buildPaths.html %>',
     },


### PR DESCRIPTION
This PR adjusts the source directories scanned by drushmake's `newer` configuration. Specifically, it no longer scans the `src/static` or `src/sites` directories and only performs a shallow scan of theme directories.

This is intended to avoid scanning into the Drupal files directory or the theme dependencies, as well as to simply skip some directories that really aren't best practice homes for Drupal makefiles anyway. 

This is a substitute for #273.

@mdeltito 