### PR TITLE
Do not traverse sites sub-directories on quality tasks.

### DIFF
--- a/tasks/quality.js
+++ b/tasks/quality.js
@@ -36,7 +36,8 @@ module.exports = function(grunt) {
   // Include common sites and theme locations in phplint validation.
   var phplintPatterns = defaultPatterns.slice(0);
   phplintPatterns.unshift.apply(phplintPatterns, [
-    '<%= config.srcPaths.drupal %>/sites/**/*.{php,inc}',
+    '<%= config.srcPaths.drupal %>/sites/*/*.{php,inc}',
+    '<%= config.srcPaths.drupal %>/sites/*/*/*.{php,inc}',
     '<%= config.srcPaths.drupal %>/themes/*/template.php',
     '<%= config.srcPaths.drupal %>/themes/*/templates/**/*.php',
     '<%= config.srcPaths.drupal %>/themes/*/includes/**/*.{inc,php}'


### PR DESCRIPTION
We are currently traversing into the site files directory for phplint. Let's stop doing that, as it can be a significant performance overhead for large sites, and in the case of one broken moment in Drupal 8 development, the basis to fail phplint validation on the codebase because a broken PHP file was dropped in the files directory.

Is there a one line way to specify "two levels deep, no more"?

@mdeltito 