### PR TITLE
Adding eslint for GDT

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+/node_modules
+/test/test_assets
+/test/test_assets_d8
+/test/working_copy

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
-/node_modules
 /test/test_assets
 /test/test_assets_d8
 /test/working_copy

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,8 @@
 module.exports = {
     "extends": "google",
     "rules": {
-        "max-len": "warn",
+        "max-len": 0,
         "max-nested-callbacks": ["warn", {"max": 5}],
-        "valid-jsdoc": "warn"
+        "valid-jsdoc": 0
     }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+    "extends": "google",
+    "rules": {
+        "max-len": "warn",
+        "max-nested-callbacks": ["warn", {"max": 5}],
+        "valid-jsdoc": "warn"
+    }
+};

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-    "extends": "google"
-}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+    "extends": "google"
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ before_install:
 install:
   - npm install -g grunt-cli@^1.0.0
   - npm install -g mocha
+  - npm install
   - ls -lRa
 script:
   - echo "Code checkout disk usage"; du -chs .

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ install:
   - ls -lRa
 script:
   - echo "Code checkout disk usage"; du -chs .
+  - npm run lint
   - ./test/create_working_copy.sh
   - cd test/working_copy/
   - echo "Working copy disk usage"; du -chs .

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -5,8 +5,7 @@ module.exports = function(grunt) {
     grunt.initConfig({
       config: config
     });
-  }
-  else {
+  } else {
     grunt.config.set('config', config);
   }
 
@@ -16,10 +15,11 @@ module.exports = function(grunt) {
   // Wrap Grunt's loadNpmTasks() function to allow loading Grunt task modules
   // that are dependencies of Grunt Drupal Tasks.
   grunt._loadNpmTasks = grunt.loadNpmTasks;
-  grunt.loadNpmTasks = function (mod) {
+  grunt.loadNpmTasks = function(mod) {
     var internalMod = grunt.file.exists(__dirname, 'node_modules', mod);
+    var pathOrig;
     if (internalMod) {
-      var pathOrig = process.cwd();
+      pathOrig = process.cwd();
       process.chdir(__dirname);
     }
     grunt._loadNpmTasks(mod);
@@ -29,12 +29,14 @@ module.exports = function(grunt) {
   };
 
   // Load all tasks from grunt-drupal-tasks.
-  grunt.loadTasks(__dirname + '/tasks');
+  var path = require('path');
+  grunt.loadTasks(path.join(__dirname, '/tasks'));
 
   // Define the default task to fully build and configure the project.
   var tasksDefault = [];
 
-  // If the "--no-validate" option is given, skip adding "validate" to task array.
+  // If the "--no-validate" option is given, skip adding "validate" to default
+  // tasks array.
   if (!grunt.option('no-validate')) {
     tasksDefault.push('validate');
   }
@@ -47,8 +49,7 @@ module.exports = function(grunt) {
   // any one run does not impact later behavior.
   if (grunt.file.exists(grunt.config.get('config.buildPaths.html') + '/index.php')) {
     tasksDefault.push('newer:drushmake:default');
-  }
-  else {
+  } else {
     tasksDefault.push('drushmake:default');
   }
 

--- a/example/Gruntfile.js
+++ b/example/Gruntfile.js
@@ -1,6 +1,4 @@
 module.exports = function(grunt) {
-
   // Load all plugins and tasks defined by the grunt-drupal-tasks package.
   require('grunt-drupal-tasks')(grunt);
-
 };

--- a/lib/drupal.js
+++ b/lib/drupal.js
@@ -5,7 +5,7 @@ module.exports = function(grunt) {
 
   // loadDrushStatus must be run before functions that require Drush status
   // information, such as majorVersion().
-  module.loadDrushStatus = function (callback) {
+  module.loadDrushStatus = function(callback) {
     // Only let this run once per grunt execution.
     if (grunt.config('drupal')) {
       return callback(null, grunt.config('drupal'));
@@ -16,12 +16,10 @@ module.exports = function(grunt) {
       var json = null;
       if (error) {
         grunt.log.writeln('drush status failed with code ' + code);
-      }
-      else {
+      } else {
         try {
           json = JSON.parse(result);
-        }
-        catch (e) {
+        } catch (e) {
           grunt.log.writeln('drush status did not produce valid JSON.');
         }
       }
@@ -32,9 +30,9 @@ module.exports = function(grunt) {
   };
 
   module.majorVersion = function() {
-    var version = grunt.config('drupal.drupal-version') || '',
-      versionParts = version ? version.match(/^\d+/) : '';
-    return versionParts.length ? parseInt(versionParts[0]) : 0;
+    var version = grunt.config('drupal.drupal-version') || '';
+    var versionParts = version ? version.match(/^\d+/) : '';
+    return versionParts.length ? parseInt(versionParts[0], 10) : 0;
   };
 
   module.modulePath = function() {
@@ -76,17 +74,15 @@ module.exports = function(grunt) {
     if (grunt.config('config.project.dbConnection')) {
       return callback(null, grunt.config('config.project.dbConnection'));
     }
-    grunt.util.spawn({cmd: module.drushPath(), args: ['-r', grunt.config('config.buildPaths.html'), 'sql-connect']}, function(error, result, code) {
+    grunt.util.spawn({cmd: module.drushPath(), args: ['-r', grunt.config('config.buildPaths.html'), 'sql-connect']}, function(error, result) {
       if (error) {
         grunt.log.writeln('drush sql-connect failed with error ' + error);
-      }
-      else {
+      } else {
         grunt.config('config.project.dbConnection', result);
       }
       callback(error, result);
     });
-  }
+  };
 
   return module;
-
 };

--- a/lib/help.js
+++ b/lib/help.js
@@ -16,7 +16,7 @@ module.exports = function(grunt) {
       if (groups === undefined) {
         groups = {};
       }
-      if (groups[group] === undefined ) {
+      if (groups[group] === undefined) {
         groups[group] = [];
       }
       groups[group].push(task);
@@ -34,9 +34,8 @@ module.exports = function(grunt) {
       items.forEach(function(item) {
         module.addItem(item.task, item.group, item.description);
       });
-    }
-    else if (items instanceof Object) {
-      module.addItem(items.task, items.group, items.description)
+    } else if (items instanceof Object) {
+      module.addItem(items.task, items.group, items.description);
     }
   };
 

--- a/lib/init.js
+++ b/lib/init.js
@@ -3,20 +3,21 @@ var _ = require('lodash');
 module.exports = function(grunt) {
   var module = {};
 
-  // Allow projects to insert config into the gdt namespace before loading GDT bootstrap.
-  // This will take precedence over environment or project-shipped config.
-  module.magic = function (name, envName) {
+  // Allow projects to insert config into the gdt namespace before loading GDT
+  // bootstrap. This will take precedence over environment or project-shipped
+  // config.
+  module.magic = function(name, envName) {
     envName = envName || name;
 
-    return grunt.config(['gdt'].concat(name))
-      || process.env['GDT_' + envName.toUpperCase()]
-      || grunt.config(['config'].concat(name));
-  }
+    return grunt.config(['gdt'].concat(name)) ||
+      process.env['GDT_' + envName.toUpperCase()] ||
+      grunt.config(['config'].concat(name));
+  };
 
   // Ensure a default URL for the project.
   module.siteUrls = function() {
     return grunt.config('config.siteUrls.default') || "http://<%= config.domain %>";
-  }
+  };
 
   module.buildPaths = function() {
     // Set implicit global configuration.
@@ -30,7 +31,7 @@ module.exports = function(grunt) {
     }, buildPaths);
 
     return buildPaths;
-  }
+  };
 
   module.themes = function(themes) {
     // If the theme path is not set give it a sane default.
@@ -39,11 +40,12 @@ module.exports = function(grunt) {
         grunt.config(['themes', key, 'path'], "<%= config.srcPaths.drupal %>/themes/" + key);
       }
     }
-  }
+  };
 
   module.init = function() {
-    if (grunt.config('config.siteUrls') === undefined)
+    if (grunt.config('config.siteUrls') === undefined) {
       grunt.config('config.siteUrls', {});
+    }
 
     grunt.config('config.domain', module.magic('domain') || require('os').hostname());
     grunt.config('config.alias', module.magic('alias', 'SITE_ALIAS') || '@' + grunt.config('config.domain'));
@@ -52,7 +54,7 @@ module.exports = function(grunt) {
     grunt.config('config.siteUrls.default', module.siteUrls());
     grunt.config('config.buildPaths', module.buildPaths());
 
-    module.buildPaths(grunt.config('config.themes'))
+    module.buildPaths(grunt.config('config.themes'));
   };
 
   return module;

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -15,11 +15,10 @@ module.exports = function(grunt) {
     }
 
     return 'shell:' + name + '-dispatch';
-  }
+  };
 
   /**
    * Generate configuration and retrieve commands for an arbitrary task name.
-   *
    * Useful to add configuration-driven "events" to other tasks.
    */
   module.eventify = function(scripts, task, namespace, tasks) {
@@ -31,7 +30,6 @@ module.exports = function(grunt) {
     if (scripts['pre-' + task]) {
       command = buildCmd('pre-' + namespace, scripts['pre-' + task]);
       tasks.unshift(command);
-
     }
     if (scripts['post-' + task]) {
       command = buildCmd('post-' + namespace, scripts['post-' + task]);
@@ -39,24 +37,23 @@ module.exports = function(grunt) {
     }
 
     return tasks;
-  }
+  };
 
-  // Generate configuration and retrieve commands for a defined script operation.
+  // Generate configuration and retrieve commands for a defined script task.
   module.handle = function(config, task, namespace) {
     var command = '';
 
-    if (task == undefined) {
-      if (config.scripts == undefined) {
+    if (task === undefined) {
+      if (config.scripts === undefined) {
         grunt.log.writeln("No scripts have been configured.");
-      }
-      else {
+      } else {
         module.usage(config.scripts);
       }
       return command;
     }
 
     if (config.scripts[task]) {
-      var command = [];
+      command = [];
       if (config.scripts['pre-' + task]) {
         command.push(buildCmd(
           'pre-' + namespace,
@@ -82,21 +79,21 @@ module.exports = function(grunt) {
           }
         ));
       }
-    }
-    else {
+    } else {
       grunt.log.writeln('The ' + namespace + ' command "' + task + '"" is not available. Select from the following:');
       module.usage(config.scripts);
     }
 
     return command;
-  }
+  };
 
   module.usage = function(scripts) {
-    for (var key in scripts) {
+    var _ = require('lodash');
+    _.each(scripts, function(script, key) {
       grunt.log.writeln(key + '\t:\t' + scripts[key]);
-    }
+    });
     grunt.log.writeln('Scripts named with "pre-<op>" or "post-<op>" are automatically run before or after their respective <op> operation.');
-  }
+  };
 
   return module;
-}
+};

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,7 +4,7 @@ module.exports = {
   concurrency: Math.max((require('os').cpus().length || 1) * 2, 2),
   // Assemble an array of absolute URLs
   expandUrls: function(baseUrl, paths) {
-    return paths.map(function(value, index, arr) {
+    return paths.map(function(value) {
       return baseUrl + value;
     });
   },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -24,12 +24,12 @@
         },
         "path-is-absolute": {
           "version": "1.0.0",
-          "from": "path-is-absolute@>=1.0.0 <1.1.0",
+          "from": "path-is-absolute@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
         },
         "rimraf": {
           "version": "2.5.2",
-          "from": "rimraf@>=2.2.8 <3.0.0",
+          "from": "rimraf@>=2.5.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
           "dependencies": {
             "glob": {
@@ -631,22 +631,10 @@
               "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz"
             },
             "which": {
-              "version": "1.2.8",
+              "version": "1.2.9",
               "from": "which@>=1.2.1 <1.3.0",
-              "resolved": "https://registry.npmjs.org/which/-/which-1.2.8.tgz",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.2.9.tgz",
               "dependencies": {
-                "is-absolute": {
-                  "version": "0.1.7",
-                  "from": "is-absolute@>=0.1.7 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
-                  "dependencies": {
-                    "is-relative": {
-                      "version": "0.1.3",
-                      "from": "is-relative@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
-                    }
-                  }
-                },
                 "isexe": {
                   "version": "1.1.2",
                   "from": "isexe@>=1.1.1 <2.0.0",
@@ -810,7 +798,7 @@
         },
         "async": {
           "version": "1.5.2",
-          "from": "async@>=1.5.2 <2.0.0",
+          "from": "async@>=1.2.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "indent-string": {
@@ -932,7 +920,7 @@
                           "dependencies": {
                             "spdx-license-ids": {
                               "version": "1.2.1",
-                              "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                             }
                           }
@@ -949,7 +937,7 @@
                             },
                             "spdx-license-ids": {
                               "version": "1.2.1",
-                              "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                             }
                           }
@@ -1146,10 +1134,15 @@
                       }
                     },
                     "readable-stream": {
-                      "version": "2.1.2",
+                      "version": "2.1.4",
                       "from": "readable-stream@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
                       "dependencies": {
+                        "buffer-shims": {
+                          "version": "1.0.0",
+                          "from": "buffer-shims@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                        },
                         "core-util-is": {
                           "version": "1.0.2",
                           "from": "core-util-is@>=1.0.0 <1.1.0",
@@ -1181,7 +1174,7 @@
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "pump": {
@@ -1251,7 +1244,7 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
@@ -1294,7 +1287,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "from": "async@>=1.5.2 <2.0.0",
+          "from": "async@>=1.2.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "rimraf": {
@@ -1372,64 +1365,40 @@
       }
     },
     "grunt-contrib-compress": {
-      "version": "1.2.0",
+      "version": "1.3.0",
       "from": "grunt-contrib-compress@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-compress/-/grunt-contrib-compress-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-compress/-/grunt-contrib-compress-1.3.0.tgz",
       "dependencies": {
         "archiver": {
-          "version": "0.21.0",
-          "from": "archiver@>=0.21.0 <0.22.0",
-          "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.21.0.tgz",
+          "version": "1.0.0",
+          "from": "archiver@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.0.0.tgz",
           "dependencies": {
             "archiver-utils": {
-              "version": "0.3.0",
-              "from": "archiver-utils@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-0.3.0.tgz",
+              "version": "1.2.0",
+              "from": "archiver-utils@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.2.0.tgz",
               "dependencies": {
+                "graceful-fs": {
+                  "version": "4.1.4",
+                  "from": "graceful-fs@>=4.1.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
+                },
                 "lazystream": {
-                  "version": "0.1.0",
-                  "from": "lazystream@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "1.0.34",
-                      "from": "readable-stream@>=1.0.2 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
+                  "version": "1.0.0",
+                  "from": "lazystream@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz"
                 },
                 "normalize-path": {
                   "version": "2.0.1",
-                  "from": "normalize-path@>=2.0.0 <2.1.0",
+                  "from": "normalize-path@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
                 }
               }
             },
             "async": {
               "version": "1.5.2",
-              "from": "async@>=1.5.0 <1.6.0",
+              "from": "async@>=1.5.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
             },
             "buffer-crc32": {
@@ -1438,9 +1407,9 @@
               "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz"
             },
             "glob": {
-              "version": "6.0.4",
-              "from": "glob@>=6.0.0 <6.1.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+              "version": "7.0.3",
+              "from": "glob@>=7.0.0 <8.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.5",
@@ -1502,16 +1471,16 @@
                 }
               }
             },
-            "lodash": {
-              "version": "3.10.1",
-              "from": "lodash@>=3.10.0 <3.11.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-            },
             "readable-stream": {
-              "version": "2.0.6",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+              "version": "2.1.4",
+              "from": "readable-stream@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz",
               "dependencies": {
+                "buffer-shims": {
+                  "version": "1.0.0",
+                  "from": "buffer-shims@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                },
                 "core-util-is": {
                   "version": "1.0.2",
                   "from": "core-util-is@>=1.0.0 <1.1.0",
@@ -1545,14 +1514,53 @@
               }
             },
             "tar-stream": {
-              "version": "1.3.2",
-              "from": "tar-stream@>=1.3.1 <1.4.0",
-              "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.3.2.tgz",
+              "version": "1.5.2",
+              "from": "tar-stream@>=1.5.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
               "dependencies": {
                 "bl": {
                   "version": "1.1.2",
                   "from": "bl@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz"
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "2.0.6",
+                      "from": "readable-stream@>=2.0.5 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "1.0.0",
+                          "from": "isarray@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.7",
+                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
                 },
                 "end-of-stream": {
                   "version": "1.1.0",
@@ -1561,7 +1569,7 @@
                   "dependencies": {
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <1.4.0",
+                      "from": "once@>=1.3.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
@@ -1581,19 +1589,19 @@
               }
             },
             "zip-stream": {
-              "version": "0.8.0",
-              "from": "zip-stream@>=0.8.0 <0.9.0",
-              "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.8.0.tgz",
+              "version": "1.0.0",
+              "from": "zip-stream@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.0.0.tgz",
               "dependencies": {
                 "compress-commons": {
-                  "version": "0.4.2",
-                  "from": "compress-commons@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.4.2.tgz",
+                  "version": "1.0.0",
+                  "from": "compress-commons@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.0.0.tgz",
                   "dependencies": {
                     "crc32-stream": {
-                      "version": "0.4.0",
-                      "from": "crc32-stream@>=0.4.0 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.4.0.tgz"
+                      "version": "1.0.0",
+                      "from": "crc32-stream@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-1.0.0.tgz"
                     },
                     "node-int64": {
                       "version": "0.4.0",
@@ -1602,7 +1610,7 @@
                     },
                     "normalize-path": {
                       "version": "2.0.1",
-                      "from": "normalize-path@>=2.0.0 <2.1.0",
+                      "from": "normalize-path@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
                     }
                   }
@@ -1746,7 +1754,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "from": "async@>=1.5.2 <2.0.0",
+          "from": "async@>=1.2.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "gaze": {
@@ -1901,9 +1909,9 @@
                   }
                 },
                 "type-is": {
-                  "version": "1.6.12",
+                  "version": "1.6.13",
                   "from": "type-is@>=1.6.10 <1.7.0",
-                  "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz",
+                  "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
                   "dependencies": {
                     "media-typer": {
                       "version": "0.3.0",
@@ -1912,7 +1920,7 @@
                     },
                     "mime-types": {
                       "version": "2.1.11",
-                      "from": "mime-types@>=2.1.10 <2.2.0",
+                      "from": "mime-types@>=2.1.11 <2.2.0",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
                       "dependencies": {
                         "mime-db": {
@@ -1944,9 +1952,9 @@
               "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
               "dependencies": {
                 "websocket-driver": {
-                  "version": "0.6.4",
+                  "version": "0.6.5",
                   "from": "websocket-driver@>=0.5.1",
-                  "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.4.tgz",
+                  "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
                   "dependencies": {
                     "websocket-extensions": {
                       "version": "0.1.1",
@@ -2048,881 +2056,6 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
-        },
-        "eslint": {
-          "version": "2.10.2",
-          "from": "eslint@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.10.2.tgz",
-          "dependencies": {
-            "concat-stream": {
-              "version": "1.5.1",
-              "from": "concat-stream@>=1.4.6 <2.0.0",
-              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "typedarray": {
-                  "version": "0.0.6",
-                  "from": "typedarray@>=0.0.5 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-                },
-                "readable-stream": {
-                  "version": "2.0.6",
-                  "from": "readable-stream@>=2.0.0 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "from": "isarray@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.7",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "debug": {
-              "version": "2.2.0",
-              "from": "debug@>=2.1.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-              "dependencies": {
-                "ms": {
-                  "version": "0.7.1",
-                  "from": "ms@0.7.1",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                }
-              }
-            },
-            "doctrine": {
-              "version": "1.2.1",
-              "from": "doctrine@>=1.2.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.2.1.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "1.1.6",
-                  "from": "esutils@>=1.1.6 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "from": "isarray@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                }
-              }
-            },
-            "es6-map": {
-              "version": "0.1.3",
-              "from": "es6-map@>=0.1.3 <0.2.0",
-              "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.3.tgz",
-              "dependencies": {
-                "d": {
-                  "version": "0.1.1",
-                  "from": "d@>=0.1.1 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
-                },
-                "es5-ext": {
-                  "version": "0.10.11",
-                  "from": "es5-ext@>=0.10.8 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
-                },
-                "es6-iterator": {
-                  "version": "2.0.0",
-                  "from": "es6-iterator@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
-                },
-                "es6-set": {
-                  "version": "0.1.4",
-                  "from": "es6-set@>=0.1.3 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz"
-                },
-                "es6-symbol": {
-                  "version": "3.0.2",
-                  "from": "es6-symbol@>=3.0.1 <3.1.0",
-                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
-                },
-                "event-emitter": {
-                  "version": "0.3.4",
-                  "from": "event-emitter@>=0.3.4 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
-                }
-              }
-            },
-            "escope": {
-              "version": "3.6.0",
-              "from": "escope@>=3.6.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-              "dependencies": {
-                "es6-weak-map": {
-                  "version": "2.0.1",
-                  "from": "es6-weak-map@>=2.0.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
-                  "dependencies": {
-                    "d": {
-                      "version": "0.1.1",
-                      "from": "d@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
-                    },
-                    "es5-ext": {
-                      "version": "0.10.11",
-                      "from": "es5-ext@>=0.10.8 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
-                    },
-                    "es6-iterator": {
-                      "version": "2.0.0",
-                      "from": "es6-iterator@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
-                    },
-                    "es6-symbol": {
-                      "version": "3.0.2",
-                      "from": "es6-symbol@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz"
-                    }
-                  }
-                },
-                "esrecurse": {
-                  "version": "4.1.0",
-                  "from": "esrecurse@>=4.1.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
-                  "dependencies": {
-                    "estraverse": {
-                      "version": "4.1.1",
-                      "from": "estraverse@>=4.1.0 <4.2.0",
-                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
-                    },
-                    "object-assign": {
-                      "version": "4.1.0",
-                      "from": "object-assign@>=4.0.1 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "espree": {
-              "version": "3.1.4",
-              "from": "espree@3.1.4",
-              "resolved": "https://registry.npmjs.org/espree/-/espree-3.1.4.tgz",
-              "dependencies": {
-                "acorn": {
-                  "version": "3.1.0",
-                  "from": "acorn@>=3.1.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.1.0.tgz"
-                },
-                "acorn-jsx": {
-                  "version": "3.0.1",
-                  "from": "acorn-jsx@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz"
-                }
-              }
-            },
-            "estraverse": {
-              "version": "4.2.0",
-              "from": "estraverse@>=4.2.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "from": "esutils@>=2.0.2 <3.0.0",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-            },
-            "file-entry-cache": {
-              "version": "1.2.4",
-              "from": "file-entry-cache@>=1.1.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz",
-              "dependencies": {
-                "flat-cache": {
-                  "version": "1.0.10",
-                  "from": "flat-cache@>=1.0.9 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.10.tgz",
-                  "dependencies": {
-                    "del": {
-                      "version": "2.2.0",
-                      "from": "del@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/del/-/del-2.2.0.tgz",
-                      "dependencies": {
-                        "globby": {
-                          "version": "4.0.0",
-                          "from": "globby@>=4.0.0 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/globby/-/globby-4.0.0.tgz",
-                          "dependencies": {
-                            "array-union": {
-                              "version": "1.0.1",
-                              "from": "array-union@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
-                              "dependencies": {
-                                "array-uniq": {
-                                  "version": "1.0.2",
-                                  "from": "array-uniq@>=1.0.1 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
-                                }
-                              }
-                            },
-                            "arrify": {
-                              "version": "1.0.1",
-                              "from": "arrify@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
-                            },
-                            "glob": {
-                              "version": "6.0.4",
-                              "from": "glob@>=6.0.1 <7.0.0",
-                              "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-                              "dependencies": {
-                                "inflight": {
-                                  "version": "1.0.5",
-                                  "from": "inflight@>=1.0.4 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-                                  "dependencies": {
-                                    "wrappy": {
-                                      "version": "1.0.2",
-                                      "from": "wrappy@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                                    }
-                                  }
-                                },
-                                "inherits": {
-                                  "version": "2.0.1",
-                                  "from": "inherits@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                                },
-                                "minimatch": {
-                                  "version": "3.0.0",
-                                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                                  "dependencies": {
-                                    "brace-expansion": {
-                                      "version": "1.1.4",
-                                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
-                                      "dependencies": {
-                                        "balanced-match": {
-                                          "version": "0.4.1",
-                                          "from": "balanced-match@>=0.4.1 <0.5.0",
-                                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
-                                        },
-                                        "concat-map": {
-                                          "version": "0.0.1",
-                                          "from": "concat-map@0.0.1",
-                                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "once": {
-                                  "version": "1.3.3",
-                                  "from": "once@>=1.3.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                                  "dependencies": {
-                                    "wrappy": {
-                                      "version": "1.0.2",
-                                      "from": "wrappy@>=1.0.0 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "is-path-cwd": {
-                          "version": "1.0.0",
-                          "from": "is-path-cwd@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
-                        },
-                        "is-path-in-cwd": {
-                          "version": "1.0.0",
-                          "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-                          "dependencies": {
-                            "is-path-inside": {
-                              "version": "1.0.0",
-                              "from": "is-path-inside@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
-                            }
-                          }
-                        },
-                        "pify": {
-                          "version": "2.3.0",
-                          "from": "pify@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.1",
-                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.4",
-                              "from": "pinkie@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                            }
-                          }
-                        },
-                        "rimraf": {
-                          "version": "2.5.2",
-                          "from": "rimraf@>=2.2.8 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz"
-                        }
-                      }
-                    },
-                    "graceful-fs": {
-                      "version": "4.1.4",
-                      "from": "graceful-fs@>=4.1.2 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
-                    },
-                    "read-json-sync": {
-                      "version": "1.1.1",
-                      "from": "read-json-sync@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.1.tgz"
-                    },
-                    "write": {
-                      "version": "0.2.1",
-                      "from": "write@>=0.2.1 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
-                    }
-                  }
-                },
-                "object-assign": {
-                  "version": "4.1.0",
-                  "from": "object-assign@>=4.0.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
-                }
-              }
-            },
-            "glob": {
-              "version": "7.0.3",
-              "from": "glob@>=7.0.3 <8.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.5",
-                  "from": "inflight@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "minimatch": {
-                  "version": "3.0.0",
-                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.4",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.4.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.4.1",
-                          "from": "balanced-match@>=0.4.1 <0.5.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.3.3",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "globals": {
-              "version": "9.6.0",
-              "from": "globals@>=9.2.0 <10.0.0",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-9.6.0.tgz"
-            },
-            "ignore": {
-              "version": "3.1.2",
-              "from": "ignore@>=3.1.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.1.2.tgz"
-            },
-            "imurmurhash": {
-              "version": "0.1.4",
-              "from": "imurmurhash@>=0.1.4 <0.2.0",
-              "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
-            },
-            "inquirer": {
-              "version": "0.12.0",
-              "from": "inquirer@>=0.12.0 <0.13.0",
-              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-              "dependencies": {
-                "ansi-escapes": {
-                  "version": "1.4.0",
-                  "from": "ansi-escapes@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
-                },
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                },
-                "cli-cursor": {
-                  "version": "1.0.2",
-                  "from": "cli-cursor@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-                  "dependencies": {
-                    "restore-cursor": {
-                      "version": "1.0.1",
-                      "from": "restore-cursor@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-                      "dependencies": {
-                        "exit-hook": {
-                          "version": "1.1.1",
-                          "from": "exit-hook@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
-                        },
-                        "onetime": {
-                          "version": "1.1.0",
-                          "from": "onetime@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "cli-width": {
-                  "version": "2.1.0",
-                  "from": "cli-width@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz"
-                },
-                "figures": {
-                  "version": "1.7.0",
-                  "from": "figures@>=1.3.5 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-                  "dependencies": {
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "from": "escape-string-regexp@>=1.0.5 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                    },
-                    "object-assign": {
-                      "version": "4.1.0",
-                      "from": "object-assign@>=4.1.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
-                    }
-                  }
-                },
-                "readline2": {
-                  "version": "1.0.1",
-                  "from": "readline2@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-                  "dependencies": {
-                    "code-point-at": {
-                      "version": "1.0.0",
-                      "from": "code-point-at@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.0",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "is-fullwidth-code-point": {
-                      "version": "1.0.0",
-                      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.0",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "mute-stream": {
-                      "version": "0.0.5",
-                      "from": "mute-stream@0.0.5",
-                      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
-                    }
-                  }
-                },
-                "run-async": {
-                  "version": "0.1.0",
-                  "from": "run-async@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-                  "dependencies": {
-                    "once": {
-                      "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "rx-lite": {
-                  "version": "3.1.2",
-                  "from": "rx-lite@>=3.1.2 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
-                },
-                "string-width": {
-                  "version": "1.0.1",
-                  "from": "string-width@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
-                  "dependencies": {
-                    "code-point-at": {
-                      "version": "1.0.0",
-                      "from": "code-point-at@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.0",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "is-fullwidth-code-point": {
-                      "version": "1.0.0",
-                      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.0",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-                },
-                "through": {
-                  "version": "2.3.8",
-                  "from": "through@>=2.3.6 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-                }
-              }
-            },
-            "is-my-json-valid": {
-              "version": "2.13.1",
-              "from": "is-my-json-valid@>=2.10.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
-              "dependencies": {
-                "generate-function": {
-                  "version": "2.0.0",
-                  "from": "generate-function@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-                },
-                "generate-object-property": {
-                  "version": "1.2.0",
-                  "from": "generate-object-property@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                  "dependencies": {
-                    "is-property": {
-                      "version": "1.0.2",
-                      "from": "is-property@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-                    }
-                  }
-                },
-                "jsonpointer": {
-                  "version": "2.0.0",
-                  "from": "jsonpointer@2.0.0",
-                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
-                },
-                "xtend": {
-                  "version": "4.0.1",
-                  "from": "xtend@>=4.0.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                }
-              }
-            },
-            "is-resolvable": {
-              "version": "1.0.0",
-              "from": "is-resolvable@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-              "dependencies": {
-                "tryit": {
-                  "version": "1.0.2",
-                  "from": "tryit@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.2.tgz"
-                }
-              }
-            },
-            "js-yaml": {
-              "version": "3.6.1",
-              "from": "js-yaml@>=3.5.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-              "dependencies": {
-                "argparse": {
-                  "version": "1.0.7",
-                  "from": "argparse@>=1.0.7 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.7.tgz",
-                  "dependencies": {
-                    "sprintf-js": {
-                      "version": "1.0.3",
-                      "from": "sprintf-js@>=1.0.2 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-                    }
-                  }
-                },
-                "esprima": {
-                  "version": "2.7.2",
-                  "from": "esprima@>=2.6.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
-                }
-              }
-            },
-            "json-stable-stringify": {
-              "version": "1.0.1",
-              "from": "json-stable-stringify@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-              "dependencies": {
-                "jsonify": {
-                  "version": "0.0.0",
-                  "from": "jsonify@>=0.0.0 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-                }
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "from": "mkdirp@>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                }
-              }
-            },
-            "optionator": {
-              "version": "0.8.1",
-              "from": "optionator@>=0.8.1 <0.9.0",
-              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz",
-              "dependencies": {
-                "prelude-ls": {
-                  "version": "1.1.2",
-                  "from": "prelude-ls@>=1.1.2 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
-                },
-                "deep-is": {
-                  "version": "0.1.3",
-                  "from": "deep-is@>=0.1.3 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
-                },
-                "wordwrap": {
-                  "version": "1.0.0",
-                  "from": "wordwrap@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
-                },
-                "type-check": {
-                  "version": "0.3.2",
-                  "from": "type-check@>=0.3.2 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
-                },
-                "levn": {
-                  "version": "0.3.0",
-                  "from": "levn@>=0.3.0 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
-                },
-                "fast-levenshtein": {
-                  "version": "1.1.3",
-                  "from": "fast-levenshtein@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz"
-                }
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.0",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-            },
-            "path-is-inside": {
-              "version": "1.0.1",
-              "from": "path-is-inside@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
-            },
-            "pluralize": {
-              "version": "1.2.1",
-              "from": "pluralize@>=1.2.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz"
-            },
-            "progress": {
-              "version": "1.1.8",
-              "from": "progress@>=1.1.8 <2.0.0",
-              "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
-            },
-            "require-uncached": {
-              "version": "1.0.2",
-              "from": "require-uncached@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.2.tgz",
-              "dependencies": {
-                "caller-path": {
-                  "version": "0.1.0",
-                  "from": "caller-path@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-                  "dependencies": {
-                    "callsites": {
-                      "version": "0.2.0",
-                      "from": "callsites@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
-                    }
-                  }
-                },
-                "resolve-from": {
-                  "version": "1.0.1",
-                  "from": "resolve-from@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
-                }
-              }
-            },
-            "shelljs": {
-              "version": "0.6.0",
-              "from": "shelljs@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.0.tgz"
-            },
-            "strip-json-comments": {
-              "version": "1.0.4",
-              "from": "strip-json-comments@>=1.0.1 <1.1.0",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
-            },
-            "table": {
-              "version": "3.7.8",
-              "from": "table@>=3.7.8 <4.0.0",
-              "resolved": "https://registry.npmjs.org/table/-/table-3.7.8.tgz",
-              "dependencies": {
-                "bluebird": {
-                  "version": "3.4.0",
-                  "from": "bluebird@>=3.1.1 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.0.tgz"
-                },
-                "slice-ansi": {
-                  "version": "0.0.4",
-                  "from": "slice-ansi@0.0.4",
-                  "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz"
-                },
-                "string-width": {
-                  "version": "1.0.1",
-                  "from": "string-width@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz",
-                  "dependencies": {
-                    "code-point-at": {
-                      "version": "1.0.0",
-                      "from": "code-point-at@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.0",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "is-fullwidth-code-point": {
-                      "version": "1.0.0",
-                      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.0",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                    }
-                  }
-                },
-                "tv4": {
-                  "version": "1.2.7",
-                  "from": "tv4@>=1.2.7 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.2.7.tgz"
-                },
-                "xregexp": {
-                  "version": "3.1.1",
-                  "from": "xregexp@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-3.1.1.tgz"
-                }
-              }
-            },
-            "text-table": {
-              "version": "0.2.0",
-              "from": "text-table@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
-            },
-            "user-home": {
-              "version": "2.0.0",
-              "from": "user-home@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.1",
-                  "from": "os-homedir@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                }
-              }
-            }
-          }
         }
       }
     },
@@ -2998,12 +2131,12 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "from": "async@>=1.5.2 <2.0.0",
+          "from": "async@>=1.2.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "rimraf": {
           "version": "2.5.2",
-          "from": "rimraf@>=2.5.2 <3.0.0",
+          "from": "rimraf@>=2.5.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
           "dependencies": {
             "glob": {
@@ -3091,22 +2224,10 @@
           "resolved": "https://registry.npmjs.org/stack-parser/-/stack-parser-0.0.1.tgz"
         },
         "which": {
-          "version": "1.2.8",
+          "version": "1.2.9",
           "from": "which@>=1.2.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.8.tgz",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.2.9.tgz",
           "dependencies": {
-            "is-absolute": {
-              "version": "0.1.7",
-              "from": "is-absolute@>=0.1.7 <0.2.0",
-              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
-              "dependencies": {
-                "is-relative": {
-                  "version": "0.1.3",
-                  "from": "is-relative@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
-                }
-              }
-            },
             "isexe": {
               "version": "1.1.2",
               "from": "isexe@>=1.1.1 <2.0.0",
@@ -3531,7 +2652,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "from": "async@>=1.2.0 <2.0.0",
+          "from": "async@>=1.2.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "lodash": {
@@ -3547,9 +2668,9 @@
       }
     },
     "lodash": {
-      "version": "4.12.0",
+      "version": "4.13.1",
       "from": "lodash@>=4.5.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.12.0.tgz"
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
     },
     "time-grunt": {
       "version": "1.3.0",
@@ -3614,7 +2735,7 @@
           "dependencies": {
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.5 <2.0.0",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "object-assign": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,11 @@
     "lodash": "^4.5.0",
     "time-grunt": "^1.3.0"
   },
+  "devDependencies": {
+    "eslint": "^2.2.0",
+    "eslint-config-google": "^0.4.0",
+    "eslint-config-xo": "^0.11.0"
+  },
   "engines": {
     "node": ">=4.0.0"
   },
@@ -48,6 +53,7 @@
     "url": "https://github.com/phase2/grunt-drupal-tasks.git"
   },
   "scripts": {
+    "lint": "eslint .; true",
     "test": "./test/test.sh"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "url": "https://github.com/phase2/grunt-drupal-tasks.git"
   },
   "scripts": {
-    "lint": "eslint .; true",
+    "lint": "eslint .",
     "test": "./test/test.sh"
   }
 }

--- a/tasks/behat.js
+++ b/tasks/behat.js
@@ -1,5 +1,4 @@
 module.exports = function(grunt) {
-
   /**
    * Define "behat" tasks.
    *
@@ -26,9 +25,8 @@ module.exports = function(grunt) {
    *   }
    */
   grunt.loadNpmTasks('grunt-parallel-behat');
-  var config = grunt.config.get('config'),
-    flags = '',
-    _ = require('lodash');
+  var config = grunt.config.get('config');
+  var _ = require('lodash');
 
   if (config.buildPaths.html && config.siteUrls) {
     for (var key in config.siteUrls) {
@@ -60,7 +58,7 @@ module.exports = function(grunt) {
               bin: 'vendor/bin/behat',
               debug: true,
               env: _.extend({}, process.env, {
-                "BEHAT_PARAMS": "{\"extensions\": {\"Drupal\\\\DrupalExtension\": {\"drupal\": {\"drupal_root\": \"./" + config.buildPaths.html + "\"}}, \"Behat\\\\MinkExtension\": {\"base_url\": \"" + config.siteUrls[key] + "\", \"zombie\": {\"node_modules_path\": \"" + process.cwd() + "/node_modules/\"}}}}"
+                BEHAT_PARAMS: "{\"extensions\": {\"Drupal\\\\DrupalExtension\": {\"drupal\": {\"drupal_root\": \"./" + config.buildPaths.html + "\"}}, \"Behat\\\\MinkExtension\": {\"base_url\": \"" + config.siteUrls[key] + "\", \"zombie\": {\"node_modules_path\": \"" + process.cwd() + "/node_modules/\"}}}}"
               })
             }, options)
           }

--- a/tasks/clean.js
+++ b/tasks/clean.js
@@ -1,5 +1,4 @@
 module.exports = function(grunt) {
-
   /**
    * Define "clean" tasks to remove files and directories.
    *

--- a/tasks/composer.js
+++ b/tasks/composer.js
@@ -1,12 +1,11 @@
 module.exports = function(grunt) {
-
   /**
    * Define "composer" tasks.
    *
    * Dynamically adds a Composer install task if a composer.json file
    * exists in the project directory.
    */
-  var config = grunt.config.get('config');
+
   if (require('fs').existsSync('./composer.json')) {
     grunt.loadNpmTasks('grunt-composer');
     var Help = require('../lib/help')(grunt);
@@ -17,14 +16,15 @@ module.exports = function(grunt) {
           'no-interaction',
           'no-progress',
           'prefer-dist'
-        ],
+        ]
       }
     });
 
     Help.add({
       task: 'composer',
       group: 'Dependency Management',
-      description: 'Install dependencies defined in this project\'s composer.json file.'
+      description:
+        "Install dependencies defined in this project's composer.json file."
     });
   }
 };

--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -1,12 +1,12 @@
 module.exports = function(grunt) {
-
   /**
    * Define "copy" tasks.
    *
    * grunt copy:static
    *   Copies all files from src/static to the build/html directory.
    * grunt rsync:tempbuild
-   *   Duplicate Drupal docroot from temporary location to the final build target.
+   *   Duplicate Drupal docroot from temporary location to the final build
+   *    target.
    * grunt copy:tempbuild
    *   Original implementation of rsync:tempbuild, preserved for backwards
    *   compatibility and Windows support.
@@ -56,7 +56,7 @@ module.exports = function(grunt) {
       ],
       src: '<%= config.buildPaths.temp %>/',
       dest: '<%= config.buildPaths.html %>'
-    },
+    }
   });
 
   grunt.config('copy.defaults', {
@@ -72,5 +72,4 @@ module.exports = function(grunt) {
       }
     ]
   });
-
 };

--- a/tasks/git.js
+++ b/tasks/git.js
@@ -1,14 +1,12 @@
 var _ = require('lodash');
 
 module.exports = function(grunt) {
-
   /**
    * Define tasks for automatic setup of a local project git repo.
    *
    * These are tasks that cannot be initialized into the repository via Yeoman,
    * such as githooks.
    */
-
 
   if (!grunt.file.exists('build') && !grunt.file.exists('.git/hooks/pre-comit') && !grunt.config('config.validate.ignoreError')) {
     grunt.log.writeln('Run `grunt git-setup` to perform one-time repo upgrades, such as adding a pre-commit code scanner.');
@@ -21,7 +19,7 @@ module.exports = function(grunt) {
     if (tasks !== undefined) {
       tasks = [];
     }
-    tasks.push('validate:staged')
+    tasks.push('validate:staged');
 
     // Githooks task may be configured via Gruntconfig.
     grunt.config('githooks', {

--- a/tasks/help.js
+++ b/tasks/help.js
@@ -1,11 +1,11 @@
 module.exports = function(grunt) {
-
   /**
    * Define "help" task, a more purposeful and structured help than -h.
    *
    * grunt help
    *   Provides an overview of intended and useful grunt tasks.
    */
+  var _ = require('lodash');
 
   var Help = require('../lib/help')(grunt);
 
@@ -26,14 +26,21 @@ module.exports = function(grunt) {
   grunt.registerTask('help', 'Output grunt-drupal-tasks specialized help.', function() {
     var gdt = {};
     var gruntHelp = require('grunt/lib/grunt/help');
-    var process = function(queue) { queue.forEach(function(cb) { cb(); }); };
+    var process = function(queue) {
+      queue.forEach(function(cb) {
+        cb();
+      });
+    };
 
     gdt.cleanOptions = function() {
-      for (var i in gruntHelp._options) {
-        item = gruntHelp._options[i];
-        if (item[0] == '--base' || item[0] == '--gruntfile' || item[0] == '--tasks' || item[0] == '--npm') delete gruntHelp._options[i];
-        if (item[0] == '--help, -h') gruntHelp._options[i][1] = 'Display the default Grunt help text.';
-      }
+      _.each(gruntHelp._options, function(item, i) {
+        if (item[0] === '--base' || item[0] === '--gruntfile' || item[0] === '--tasks' || item[0] === '--npm') {
+          delete gruntHelp._options[i];
+        }
+        if (item[0] === '--help, -h') {
+          gruntHelp._options[i][1] = 'Display the default Grunt help text.';
+        }
+      });
     };
 
     gdt.header = function() {
@@ -43,13 +50,13 @@ module.exports = function(grunt) {
 
     gdt.options = function() {
       var options = [
-        [ '--concurrency', 'Override the dynamic concurrency parameter used by Drush Make.' ],
-        [ '--db-url', 'Pass thru your Drupal database credentials for site installation.' ],
-        [ '--name', 'Override the name of the package exported by "grunt package".' ],
-        [ '--notify', 'Request a desktop notification despite timing or environment settings.' ],
-        [ '--no-validate', 'Skip `grunt:validate` in the default `grunt` task.' ],
-        [ '--quiet', 'Suppress desktop notifications.' ],
-        [ '--timer', 'Output task execution timing info.' ]
+        ['--concurrency', 'Override the dynamic concurrency parameter used by Drush Make.'],
+        ['--db-url', 'Pass thru your Drupal database credentials for site installation.'],
+        ['--name', 'Override the name of the package exported by "grunt package".'],
+        ['--notify', 'Request a desktop notification despite timing or environment settings.'],
+        ['--no-validate', 'Skip `grunt:validate` in the default `grunt` task.'],
+        ['--quiet', 'Suppress desktop notifications.'],
+        ['--timer', 'Output task execution timing info.']
       ];
 
       if (grunt.config('config.project.db')) {
@@ -76,7 +83,6 @@ module.exports = function(grunt) {
         gruntHelp.footer,
         gdt.footer
       ];
-
       process(queue);
     });
 

--- a/tasks/install.js
+++ b/tasks/install.js
@@ -1,5 +1,4 @@
 module.exports = function(grunt) {
-
   /**
    * Define tasks to quickly get Drupal running.
    *
@@ -13,16 +12,16 @@ module.exports = function(grunt) {
    */
   grunt.loadNpmTasks('grunt-drush');
 
-  var Help = require('../lib/help')(grunt),
-    Drupal = require('../lib/drupal')(grunt),
-    path = require('path'),
-    _ = require('lodash');
+  var Help = require('../lib/help')(grunt);
+  var Drupal = require('../lib/drupal')(grunt);
+
+  var _ = require('lodash');
 
   // If no path is configured for Drush, fallback to the system path.
-  var cmd = {cmd: Drupal.drushPath()},
-    args = [ '--root=<%= config.buildPaths.html %>' ],
-    profile = grunt.config('config.project.profile') || 'standard',
-    dbUrl = grunt.option('db-url') || '';
+  var cmd = {cmd: Drupal.drushPath()};
+  var args = ['--root=<%= config.buildPaths.html %>'];
+  var profile = grunt.config('config.project.profile') || 'standard';
+  var dbUrl = grunt.option('db-url') || '';
 
   if (dbUrl) {
     dbUrl = '--db-url=' + dbUrl;
@@ -39,7 +38,7 @@ module.exports = function(grunt) {
     }, cmd)
   });
   grunt.config(['drush', 'updb'], {
-    args: args.concat(['updatedb', '-y' ]),
+    args: args.concat(['updatedb', '-y']),
     options: _.extend({
     }, cmd)
   });
@@ -66,7 +65,7 @@ module.exports = function(grunt) {
           // Load new database.
           'shell:loaddb',
           // Run any pending database updates.
-          'drush:updb',
+          'drush:updb'
         ];
 
         tasks = require('../lib/scripts')(grunt)
@@ -75,8 +74,7 @@ module.exports = function(grunt) {
         grunt.task.run(tasks);
         done();
       });
-    }
-    else {
+    } else {
       var tasks = [
         // Run site install.
         'drush:install'

--- a/tasks/make.js
+++ b/tasks/make.js
@@ -1,5 +1,4 @@
 module.exports = function(grunt) {
-
   /**
    * Define "drush" tasks.
    *
@@ -9,33 +8,36 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-drush');
   grunt.loadNpmTasks('grunt-newer');
 
-  var Help = require('../lib/help')(grunt),
-    Drupal = require('../lib/drupal')(grunt),
-    gdt = require('../lib/util');
+  var Help = require('../lib/help')(grunt);
+  var Drupal = require('../lib/drupal')(grunt);
+  var gdt = require('../lib/util');
 
-  var path = require('path'),
-    _ = require('lodash');
+  var _ = require('lodash');
 
   // If no path is configured for Drush, fallback to the system path.
   var cmd = {cmd: Drupal.drushPath()};
 
   // Allow extra arguments for drush to be supplied.
-  var make_args = ['make', '<%= config.srcPaths.make %>', '<%= config.buildPaths.temp %>'];
-  var extra_args = grunt.config.get('config.drush.make.args');
+  var makeArgs = [
+    'make',
+    '<%= config.srcPaths.make %>',
+    '<%= config.buildPaths.temp %>'
+  ];
+  var extraArgs = grunt.config.get('config.drush.make.args');
 
-  if (extra_args && extra_args.length) {
-    extra_args.unshift(make_args[0]);
-    extra_args.push(make_args[1]);
-    extra_args.push(make_args[2]);
-    make_args = extra_args;
+  if (extraArgs && extraArgs.length) {
+    extraArgs.unshift(makeArgs[0]);
+    extraArgs.push(makeArgs[1]);
+    extraArgs.push(makeArgs[2]);
+    makeArgs = extraArgs;
   }
 
   var limit = grunt.option('concurrency') || require('../lib/util').concurrency;
-  make_args.push('--concurrency=' + limit);
+  makeArgs.push('--concurrency=' + limit);
   grunt.verbose.writeln('Configured for concurrency=' + limit);
 
   grunt.config(['drush', 'make'], {
-    args: make_args,
+    args: makeArgs,
     options: _.extend({}, cmd)
   });
 
@@ -58,7 +60,7 @@ module.exports = function(grunt) {
         // Check at the immediate root of each theme.
         '<%= config.srcPaths.drupal %>/themes/*/*.{make,make.yml}'
       ],
-      dest: '<%= config.buildPaths.html %>',
+      dest: '<%= config.buildPaths.html %>'
     },
     options: {
       tasks: [

--- a/tasks/mkdir.js
+++ b/tasks/mkdir.js
@@ -1,5 +1,4 @@
 module.exports = function(grunt) {
-
   /**
    * Define "mkdir" tasks.
    *

--- a/tasks/notify.js
+++ b/tasks/notify.js
@@ -1,5 +1,4 @@
 module.exports = function(grunt) {
-
   /**
    * Define "notify" tasks.
    */
@@ -12,8 +11,11 @@ module.exports = function(grunt) {
 
   // Set the default threshold.
   var threshold = grunt.config('config.notify.threshold') || 10;
-  // If the notify flag is used, drop the threshold to ensure notifications are triggered.
-  if (grunt.option('notify')) threshold = 0;
+  // If the notify flag is used, drop the threshold to ensure notifications are
+  // triggered.
+  if (grunt.option('notify')) {
+    threshold = 0;
+  }
 
   grunt.config('notify_hooks', {
     options: {
@@ -35,5 +37,4 @@ module.exports = function(grunt) {
 
   // This is required if you use any options.
   grunt.task.run('notify_hooks');
-
 };

--- a/tasks/operations.js
+++ b/tasks/operations.js
@@ -1,14 +1,14 @@
 module.exports = function(grunt) {
-
   /**
    * Define operations tasks as configured via scripts in Gruntconfig.json
    *
    * These are ad hoc scripts with minimal facilitation from Grunt.
    */
+  var _ = require('lodash');
 
   if (grunt.config('config.scripts')) {
     var scripts = grunt.config('config.scripts');
-    for (var key in scripts) {
+    _.each(scripts, function(script, key) {
       grunt.registerTask(key, 'Perform the configured "' + key + '" task.', function() {
         var task = require('../lib/scripts')(grunt)
           .handle(grunt.config('config'), this.name, 'ops');
@@ -22,7 +22,6 @@ module.exports = function(grunt) {
         task: key,
         group: 'Operations'
       });
-    }
+    });
   }
-
-}
+};

--- a/tasks/package.js
+++ b/tasks/package.js
@@ -1,5 +1,4 @@
 module.exports = function(grunt) {
-
   /**
    * Define "package" tasks.
    *
@@ -10,12 +9,11 @@ module.exports = function(grunt) {
   var Help = require('../lib/help')(grunt);
 
   grunt.registerTask('package', 'Package the operational codebase for deployment. Use package:compress to create an archive.', function() {
-    var path = require('path');
     grunt.loadNpmTasks('grunt-contrib-copy');
 
-    var config = grunt.config.get('config.packages'),
-      srcFiles = ['**', '!**/.gitkeep'].concat((config && config.srcFiles && config.srcFiles.length) ? config.srcFiles : '**'),
-      projFiles = (config && config.projFiles && config.projFiles.length) ? config.projFiles : [];
+    var config = grunt.config.get('config.packages');
+    var srcFiles = ['**', '!**/.gitkeep'].concat((config && config.srcFiles && config.srcFiles.length) ? config.srcFiles : '**');
+    var projFiles = (config && config.projFiles && config.projFiles.length) ? config.projFiles : [];
 
     // Look for a package target spec, build destination path.
     var packageName = grunt.option('name') || config.name || 'package';
@@ -46,12 +44,12 @@ module.exports = function(grunt) {
       }
     });
 
-    grunt.config.set('clean.packages', [ destPath ]);
+    grunt.config.set('clean.packages', [destPath]);
 
     tasks.push('clean:packages');
     tasks.push('copy:package');
 
-    if (this.args[0] && this.args[0] == 'compress') {
+    if (this.args[0] && this.args[0] === 'compress') {
       grunt.loadNpmTasks('grunt-contrib-compress');
       grunt.config('compress.package', {
         options: {
@@ -60,11 +58,11 @@ module.exports = function(grunt) {
           gruntLogHeader: false
         },
         files: [
-          { 
+          {
             expand: true,
             dot: true,
             cwd: grunt.config.get('config.buildPaths.packages') + '/' + packageName,
-            src: ['**'],
+            src: ['**']
           }
         ]
       });
@@ -79,5 +77,4 @@ module.exports = function(grunt) {
     task: 'package',
     group: 'Operations'
   });
-
 };

--- a/tasks/quality.js
+++ b/tasks/quality.js
@@ -1,5 +1,4 @@
 module.exports = function(grunt) {
-
   /**
    * Define "validate" and "analyze" tasks, and include required plugins.
    *
@@ -19,8 +18,8 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-phpcs');
   grunt.loadNpmTasks('grunt-phpmd');
 
-  var Help = require('../lib/help')(grunt),
-    _ = require('lodash');
+  var Help = require('../lib/help')(grunt);
+  var _ = require('lodash');
 
   // Task set aliases are registered at the end of the file based on these values.
   var validate = [];
@@ -35,7 +34,7 @@ module.exports = function(grunt) {
 
   // Include common sites and theme locations in phplint validation.
   var phplintPatterns = defaultPatterns.slice(0);
-  phplintPatterns.unshift.apply(phplintPatterns, [
+  phplintPatterns.unshift([
     '<%= config.srcPaths.drupal %>/sites/*/*.{php,inc}',
     '<%= config.srcPaths.drupal %>/sites/*/*/*.{php,inc}',
     '<%= config.srcPaths.drupal %>/themes/*/template.php',
@@ -54,11 +53,12 @@ module.exports = function(grunt) {
 
   if (grunt.config.get('config.phpcs')) {
     var phpcs = grunt.config.get('config.phpcs.dir') || phpcsPatterns;
-    var phpStandard = grunt.config('config.phpcs.standard')
-      || 'vendor/drupal/coder/coder_sniffer/Drupal,vendor/drupal/coder/coder_sniffer/DrupalPractice';
+    var phpStandard = grunt.config('config.phpcs.standard') ||
+      'vendor/drupal/coder/coder_sniffer/Drupal,vendor/drupal/coder/coder_sniffer/DrupalPractice';
 
     // Support deprecated config.phpcs.ignoreExitCode value until 1.0.
-    var ignoreError = grunt.config('config.validate.ignoreError') || grunt.config('config.phpcs.ignoreExitCode');
+    var ignoreError = grunt.config('config.validate.ignoreError') ||
+      grunt.config('config.phpcs.ignoreExitCode');
     ignoreError = ignoreError === undefined ? false : ignoreError;
 
     grunt.config('phpcs', {
@@ -126,26 +126,26 @@ module.exports = function(grunt) {
 
   var themes = grunt.config('config.themes');
   if (grunt.config.get('config.eslint')) {
-    var eslintConfig = grunt.config.get('config.eslint'),
-      eslintTarget = eslintConfig.dir || [
-          '<%= config.srcPaths.drupal %>/themes/*/js/**/*.js',
-          '<%= config.srcPaths.drupal %>/{modules,profiles,libraries}/**/*.js'
-        ],
-      eslintTargetAnalyze = eslintTarget,
-      eslintConfigFile = eslintConfig.configFile || process.cwd() + '/.eslintrc';
+    var eslintConfig = grunt.config.get('config.eslint');
+    var eslintTarget = eslintConfig.dir || [
+      '<%= config.srcPaths.drupal %>/themes/*/js/**/*.js',
+      '<%= config.srcPaths.drupal %>/{modules,profiles,libraries}/**/*.js'
+    ];
+    var eslintTargetAnalyze = eslintTarget;
+    var eslintConfigFile = eslintConfig.configFile || process.cwd() + '/.eslintrc';
 
-    for (var key in themes) {
-      if (themes[key].scripts && themes[key].scripts.validate) {
+    _.each(themes, function(theme, key) {
+      if (theme.scripts && theme.scripts.validate) {
         // If the theme has a validate task of it's own, then exclude its
         // javascript files from our validate process.
         eslintTarget.push('!<%= config.srcPaths.drupal %>/themes/' + key + '/js/**/*.js');
       }
-      if (themes[key].scripts && themes[key].scripts.analyze) {
+      if (theme.scripts && theme.scripts.analyze) {
         // If the theme has an analyze task of it's own, then exclude its
         // javascript files from our analyze process.
         eslintTargetAnalyze.push('!<%= config.srcPaths.drupal %>/themes/' + key + '/js/**/*.js');
       }
-    }
+    });
 
     grunt.config('eslint', {
       options: {
@@ -173,43 +173,44 @@ module.exports = function(grunt) {
   }
 
   var filesToProcess = function(patterns) {
-    var paths = _.map(patterns, function (item) {
+    var paths = _.map(patterns, function(item) {
       return grunt.template.process(item);
     });
 
     // If length is evaluated to truthy at least one file matched.
     return grunt.file.expand(paths);
-  }
+  };
 
   grunt.registerTask('validate', 'Validate the quality of custom code.', function(mode) {
     var phpcs = grunt.config.get('phpcs.validate');
+    var files;
     if (phpcs) {
-      var files = filesToProcess(phpcs.src);
+      files = filesToProcess(phpcs.src);
       if (files.length) {
         grunt.config.set('phpcs.validate.src', files);
         validate.push('phpcs:validate');
       }
     }
-    var eslint = grunt.config.get('eslint.validate'),
-      eslintIgnoreError = grunt.config.get('config.validate.ignoreError') === undefined ? false : grunt.config.get('config.validate.ignoreError'),
-      eslintName = eslintIgnoreError ? 'force:eslint' : 'eslint';
+    var eslint = grunt.config.get('eslint.validate');
+    var eslintIgnoreError = grunt.config.get('config.validate.ignoreError') === undefined ? false : grunt.config.get('config.validate.ignoreError');
+    var eslintName = eslintIgnoreError ? 'force:eslint' : 'eslint';
     if (eslint) {
-      var files = filesToProcess(eslint);
+      files = filesToProcess(eslint);
       if (files.length) {
         grunt.config.set('eslint.validate', files);
         validate.push(eslintName + ':validate');
       }
     }
 
-    if (mode == 'newer' || mode == 'staged') {
+    if (mode === 'newer' || mode === 'staged') {
       // This works because grunt-newer and grunt-staged have consisting naming.
       grunt.loadNpmTasks('grunt-' + mode);
       // Wrap each task configured for validate in the newer command.
-      // grunt-phplint already contains complex caching that does the same thing.
+      // grunt-phplint contains complex caching that does the same thing.
       validate = validate.filter(function(item) {
         return item.indexOf('themes:') !== 0;
       }).map(function(item) {
-        return item != 'phplint:all' ? mode + ':' + item : item;
+        return item === 'phplint:all' ? item : mode + ':' + item;
       });
     }
 
@@ -220,19 +221,21 @@ module.exports = function(grunt) {
 
   grunt.registerTask('analyze', 'Generate reports on code quality for use by Jenkins or other visualization tools.', function() {
     var phpcs = grunt.config.get('phpcs.analyze');
+    var files;
     if (phpcs) {
-      var files = filesToProcess(phpcs.src);
+      files = filesToProcess(phpcs.src);
       if (files.length) {
         grunt.config.set('phpcs.analyze', files);
         analyze.push('phpcs:analyze');
       }
     }
-    var eslint = grunt.config.get('eslint.analyze'),
-      eslintIgnoreError = grunt.config.get('config.validate.ignoreError') === undefined ? false : grunt.config.get('config.validate.ignoreError'),
-      eslintName = eslintIgnoreError ? 'force:eslint' : 'eslint';
+    var eslint = grunt.config.get('eslint.analyze');
+    var eslintIgnoreError = grunt.config.get('config.validate.ignoreError') === undefined ? false : grunt.config.get('config.validate.ignoreError');
+    var eslintName = eslintIgnoreError ? 'force:eslint' : 'eslint';
     if (eslint) {
-      // The eslint:analyze task has a deeper configuration structure than eslint:validate.
-      var files = filesToProcess(eslint.src);
+      // The eslint:analyze task has a deeper configuration structure than
+      // eslint:validate.
+      files = filesToProcess(eslint.src);
       if (files.length) {
         grunt.config.set('eslint.analyze', files);
         analyze.push(eslintName + ':analyze');
@@ -240,6 +243,7 @@ module.exports = function(grunt) {
     }
 
     if (analyze.length) {
+      var tasks = analyze;
       if (analyze.length > 1) {
         grunt.loadNpmTasks('grunt-concurrent');
         grunt.config(['concurrent', 'analyze'], {
@@ -248,10 +252,7 @@ module.exports = function(grunt) {
             logConcurrentOutput: true
           }
         });
-        var tasks = ['concurrent:analyze']
-      }
-      else {
-        var tasks = analyze;
+        tasks = ['concurrent:analyze'];
       }
 
       tasks.unshift('mkdir:init');

--- a/tasks/scaffold.js
+++ b/tasks/scaffold.js
@@ -1,70 +1,74 @@
 module.exports = function(grunt) {
-
   /**
    * Apply the scaffolding to the Drupal docroot.
    */
-  grunt.registerTask('scaffold', 'Apply the scaffolding from ' + grunt.config('config.srcPaths.drupal') + '/ to the Drupal docroot.', function() {
-    var path = require('path');
-    if (!require('fs').existsSync(path.join(grunt.config('config.buildPaths.html'), 'index.php'))) {
-      grunt.fail.fatal('Cannot apply scaffolding until after Drupal has been built.');
-    }
-
-    var done = this.async(),
-      drupal = require('../lib/drupal')(grunt);
-    drupal.loadDrushStatus(function (err) {
-      if (err) {
-        grunt.fail.fatal('Cannot load Drush status for built Drupal docroot.\n\n' + err);
-        return done();
+  grunt.registerTask('scaffold', 'Apply the scaffolding from ' +
+    grunt.config('config.srcPaths.drupal') + '/ to the Drupal docroot.',
+    function() {
+      var path = require('path');
+      if (!require('fs').existsSync(path.join(
+        grunt.config('config.buildPaths.html'), 'index.php'))) {
+        grunt.fail.fatal('Cannot apply scaffolding until after Drupal has' +
+          ' been built.');
       }
 
-      grunt.loadNpmTasks('grunt-contrib-symlink');
-
-      grunt.config(['symlink', 'libraries'], {
-        expand: true,
-        cwd: '<%= config.srcPaths.drupal %>/libraries',
-        src: ['*'],
-        dest: drupal.libraryPath(),
-      });
-      grunt.config(['symlink', 'modules'], {
-        src: '<%= config.srcPaths.drupal %>/modules',
-        dest: path.join(drupal.modulePath(), 'custom')
-      });
-      grunt.config(['symlink', 'profiles'], {
-        expand: true,
-        cwd: '<%= config.srcPaths.drupal %>/profiles',
-        src: ['*'],
-        dest: drupal.profilePath(),
-        filter: 'isDirectory'
-      });
-      grunt.config(['symlink', 'sites'], {
-        expand: true,
-        cwd: '<%= config.srcPaths.drupal %>/sites',
-        src: ['*'],
-        dest: drupal.sitePath(),
-        filter: function (path) {
-          return (path !== '<%= config.srcPaths.drupal %>/sites/all');
+      var done = this.async();
+      var drupal = require('../lib/drupal')(grunt);
+      drupal.loadDrushStatus(function(err) {
+        if (err) {
+          grunt.fail.fatal('Cannot load Drush status for built Drupal ' +
+            'docroot.\n\n' + err);
+          return done();
         }
-      });
-      grunt.config(['symlink', 'themes'], {
-        src: '<%= config.srcPaths.drupal %>/themes',
-        dest: path.join(drupal.themePath(), 'custom')
-      });
 
-      grunt.task.run([
-        'symlink:profiles',
-        'symlink:libraries',
-        'symlink:modules',
-        'symlink:themes',
-        'copy:defaults',
-        'clean:sites',
-        'symlink:sites',
-        'mkdir:files',
-        'copy:static'
-      ]);
+        grunt.loadNpmTasks('grunt-contrib-symlink');
 
-      done();
+        grunt.config(['symlink', 'libraries'], {
+          expand: true,
+          cwd: '<%= config.srcPaths.drupal %>/libraries',
+          src: ['*'],
+          dest: drupal.libraryPath()
+        });
+        grunt.config(['symlink', 'modules'], {
+          src: '<%= config.srcPaths.drupal %>/modules',
+          dest: path.join(drupal.modulePath(), 'custom')
+        });
+        grunt.config(['symlink', 'profiles'], {
+          expand: true,
+          cwd: '<%= config.srcPaths.drupal %>/profiles',
+          src: ['*'],
+          dest: drupal.profilePath(),
+          filter: 'isDirectory'
+        });
+        grunt.config(['symlink', 'sites'], {
+          expand: true,
+          cwd: '<%= config.srcPaths.drupal %>/sites',
+          src: ['*'],
+          dest: drupal.sitePath(),
+          filter: function(path) {
+            return (path !== '<%= config.srcPaths.drupal %>/sites/all');
+          }
+        });
+        grunt.config(['symlink', 'themes'], {
+          src: '<%= config.srcPaths.drupal %>/themes',
+          dest: path.join(drupal.themePath(), 'custom')
+        });
+
+        grunt.task.run([
+          'symlink:profiles',
+          'symlink:libraries',
+          'symlink:modules',
+          'symlink:themes',
+          'copy:defaults',
+          'clean:sites',
+          'symlink:sites',
+          'mkdir:files',
+          'copy:static'
+        ]);
+
+        done();
+      });
     });
-  });
 
   require('../lib/help')(grunt).add({
     task: 'scaffold',

--- a/tasks/serve.js
+++ b/tasks/serve.js
@@ -1,5 +1,4 @@
 module.exports = function(grunt) {
-
   /**
    * Define tasks to quickly get Drupal running.
    *
@@ -13,23 +12,27 @@ module.exports = function(grunt) {
    */
   grunt.loadNpmTasks('grunt-drush');
 
-  var Help = require('../lib/help')(grunt),
-    Drupal = require('../lib/drupal')(grunt);
+  var Help = require('../lib/help')(grunt);
+  var Drupal = require('../lib/drupal')(grunt);
 
-  var path = require('path'),
-    _ = require('lodash');
+  var path = require('path');
+  var _ = require('lodash');
 
   // If no path is configured for Drush, fallback to the system path.
   var cmd = {cmd: Drupal.drushPath()};
 
   // `config.serve.profile` is deprecated.
   if (grunt.config('config.serve.profile')) {
-    grunt.log.warn('The `serve.profile` parameter is deprecated and will be removed in future versions. Use `project.profile` instead.');
+    grunt.log.warn('The `serve.profile` parameter is deprecated and will be ' +
+      'removed in future versions. Use `project.profile` instead.');
   }
-  var profile = grunt.config('config.project.profile') || grunt.config('config.serve.profile') || 'standard';
+  var profile = grunt.config('config.project.profile') ||
+    grunt.config('config.serve.profile') || 'standard';
 
   grunt.config(['drush', 'liteinstall'], {
-    args: ['site-install', '-yv', profile, '--db-url=sqlite:/' + path.join(path.resolve(grunt.config('config.buildPaths.build')), 'drupal.sqlite')],
+    args: ['site-install', '-yv', profile, '--db-url=sqlite:/' +
+      path.join(path.resolve(grunt.config('config.buildPaths.build')),
+      'drupal.sqlite')],
     options: _.extend({
       cwd: '<%= config.buildPaths.html %>'
     }, cmd)
@@ -42,44 +45,46 @@ module.exports = function(grunt) {
     }, cmd)
   });
 
-  grunt.registerTask('serve', 'Run Drupal using the PHP built-in webserver. serve:demo to run without watch tasks and serve:test for grunt-drupal-tasks development.', function() {
-
-    if (this.args[0] != 'test') {
-      // Unlike the test version, this one allows port overriding and opens the site in a new tab.
-      grunt.config('drush.serve.args', ['runserver', ':' + (grunt.config('config.serve.port') || 8080) + '/' ]);
-    }
-
-    if (this.args.length) {
-      grunt.task.run('drush:serve');
-    }
-    else {
-      grunt.loadNpmTasks('grunt-concurrent');
-
-      // Allow overriding the tasks run concurrently to the Drupal server.
-      var serveTasks = grunt.config('serve.concurrent');
-      if (!serveTasks) {
-        serveTasks = ['watch-test'];
-        if (grunt.task.exists('watch-theme')) {
-          serveTasks.push('watch-theme');
-        }
+  grunt.registerTask('serve', 'Run Drupal using the PHP built-in webserver. ' +
+    'Use serve:demo to run without watch tasks. Use serve:test for G-D-T ' +
+    'development.', function() {
+      if (this.args[0] !== 'test') {
+        // Unlike the test version, this one allows port overriding and opens
+        // the site in a new tab.
+        grunt.config('drush.serve.args', ['runserver', ':' +
+          (grunt.config('config.serve.port') || 8080) + '/']);
       }
-      serveTasks.push('drush:serve');
 
-      grunt.config('concurrent.serve', {
-        tasks: serveTasks,
-        options: {
-          logConcurrentOutput: true
+      if (this.args.length) {
+        grunt.task.run('drush:serve');
+      } else {
+        grunt.loadNpmTasks('grunt-concurrent');
+
+        // Allow overriding the tasks run concurrently to the Drupal server.
+        var serveTasks = grunt.config('serve.concurrent');
+        if (!serveTasks) {
+          serveTasks = ['watch-test'];
+          if (grunt.task.exists('watch-theme')) {
+            serveTasks.push('watch-theme');
+          }
         }
-      });
+        serveTasks.push('drush:serve');
 
-      grunt.task.run('concurrent:serve');
-    }
-  });
+        grunt.config('concurrent.serve', {
+          tasks: serveTasks,
+          options: {
+            logConcurrentOutput: true
+          }
+        });
+
+        grunt.task.run('concurrent:serve');
+      }
+    });
 
   Help.add([
     {
       task: 'serve',
       group: 'Operations'
-    },
+    }
   ]);
 };

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -1,5 +1,4 @@
 module.exports = function(grunt) {
-
   var Drupal = require('../lib/drupal')(grunt);
   var Help = require('../lib/help')(grunt);
 
@@ -11,7 +10,7 @@ module.exports = function(grunt) {
   });
 
   // @todo Would rather display as 'alias for test:behat, test:drupal, etc'.
-  grunt.registerMultiTask('test', 'Run all configured tests.', function(args) {
+  grunt.registerMultiTask('test', 'Run all configured tests.', function() {
     var self = this;
     var done = this.async();
 
@@ -21,21 +20,27 @@ module.exports = function(grunt) {
         return done();
       }
 
-      // Only run Drupal tests on D8 and higher. For D7, there is no option to run tests in a directory, so projects
-      // wishing to do this would add a separate task and hard-code the test groups that need to run.
+      // Only run Drupal tests on D8 and higher. For D7, there is no option to
+      // run tests in a directory, so projects wishing to do this would add a
+      // separate task and hard-code the test groups that need to run.
       var majorVersion = Drupal.majorVersion();
-      if (majorVersion != 8 && self.target == 'drupal') {
-        grunt.verbose.write('Running Drupal tests by directory is unsupported in Drupal 7. Create a custom task to run test groups as needed.');
+      if (majorVersion !== 8 && self.target === 'drupal') {
+        grunt.verbose.write('Running Drupal tests by directory is ' +
+          'unsupported in Drupal 7. Create a custom task to run test groups ' +
+          'as needed.');
         return done();
       }
 
       var script = './core/scripts/run-tests.sh';
       var testLocation = './modules/custom';
-      var domain = process.env.GDT_DOMAIN || grunt.config('config.domain') || require('os').hostname();
+      var domain = process.env.GDT_DOMAIN || grunt.config('config.domain') ||
+        require('os').hostname();
 
       grunt.loadNpmTasks('grunt-shell');
       grunt.config(['shell', 'testdrupal'], {
-        command: grunt.config.get('config.testing.drupal.command') || 'php ' + script + ' --verbose --color --concurrency 4 --directory ' + testLocation + ' --url ' + domain + ' --php `which php`',
+        command: grunt.config.get('config.testing.drupal.command') || 'php ' +
+          script + ' --verbose --color --concurrency 4 --directory ' +
+          testLocation + ' --url ' + domain + ' --php `which php`',
         options: {
           execOptions: {
             cwd: '<%= config.buildPaths.html %>'
@@ -51,11 +56,12 @@ module.exports = function(grunt) {
         case 'drupal':
           grunt.task.run('shell:testdrupal');
           break;
+
+        default:
       }
 
       done();
     });
-
   });
 
   Help.add({
@@ -63,4 +69,4 @@ module.exports = function(grunt) {
     group: 'Testing & Code Quality',
     description: 'Run custom module and Behat tests included with this project.'
   });
-}
+};

--- a/tasks/theme.js
+++ b/tasks/theme.js
@@ -1,11 +1,10 @@
 module.exports = function(grunt) {
-
   /**
    * Define "compile-theme" task.
    *
    * Individual themes "register" with grunt by adding a configuration object
-   * the themes section of configuration. Each theme may specify a non-default path.
-   * From there they may specify commands that should be passed to scripts
+   * the themes section of configuration. Each theme may specify a non-default
+   * path. From there they may specify commands that should be passed to scripts
    * provided with the theme.
    *
    * Example:
@@ -32,9 +31,8 @@ module.exports = function(grunt) {
    *   }
    * }
    */
-
-  var config = grunt.config.get('config'),
-    steps = [];
+  var config = grunt.config.get('config');
+  var steps = [];
 
   if (config.themes) {
     var Help = require('../lib/help')(grunt);
@@ -43,10 +41,10 @@ module.exports = function(grunt) {
       if (config.themes.hasOwnProperty(key)) {
         var theme = config.themes[key];
 
-        // If the compile-theme delegation script is truthy trigger it as part of the
-        // compile theme task. This ensures developers not working directly with the
-        // theme and CI systems can still use the primary grunt implementation as a
-        // single authority for the build process.
+        // If the compile-theme delegation script is truthy trigger it as part
+        // of the compile theme task. This ensures developers not working
+        // directly with the theme and CI systems can still use the primary
+        // grunt implementation as a single authority for the build process.
         if (theme.scripts && theme.scripts['compile-theme']) {
           steps.push('themes:' + key + ':compile-theme');
         }
@@ -62,14 +60,14 @@ module.exports = function(grunt) {
       });
     }
 
-    // Register a passthru task that can call out to theme-specific Grunt tooling.
+    // Register a passthru task that calls out to theme-specific Grunt tooling.
     grunt.registerTask('themes', 'Proxies tasks to theme-specific, pre-defined command-line operations.', function() {
       var themes = grunt.config('config.themes');
       if (!this.args[0]) {
-        for (key in themes) {
-          grunt.log.writeln(key + ' (' + themes[key].path + ')');
-        }
-        return;
+        var _ = require('lodash');
+        _.each(themes, function(theme, key) {
+          grunt.log.writeln(key + ' (' + theme.path + ')');
+        });
       }
 
       var theme = this.args[0];
@@ -86,6 +84,5 @@ module.exports = function(grunt) {
       task: 'themes',
       group: 'Utilities'
     });
-
   }
 };

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -1,5 +1,4 @@
 module.exports = function(grunt) {
-
   /**
    * Define "watch" tasks.
    *
@@ -34,14 +33,15 @@ module.exports = function(grunt) {
     }
   });
 
-  grunt.registerTask('watch-test', 'Backend operations watch task.', function() {
-    grunt.loadNpmTasks('grunt-concurrent');
-    grunt.task.run('concurrent:watch-test');
-  });
+  grunt.registerTask('watch-test', 'Backend operations watch task.',
+    function() {
+      grunt.loadNpmTasks('grunt-concurrent');
+      grunt.task.run('concurrent:watch-test');
+    });
 
   Help.add({
     task: 'watch-test',
     group: 'Real-time Tooling',
     description: 'Watch for changes that should trigger new testing and validation of the codebase.'
   });
-}
+};

--- a/test/build.js
+++ b/test/build.js
@@ -1,15 +1,16 @@
+/* global describe, it, before, after */
+
 var assert = require('assert');
 var fs = require('fs-extra');
 var exec = require('child_process').exec;
 
 describe('grunt', function() {
-
   describe('default', function() {
-    var drupalCore = process.env['GDT_DRUPAL_CORE'];
+    var drupalCore = process.env.GDT_DRUPAL_CORE;
 
     // Ensure the vendor directory exists.
     it('it should create the vendor directory', function(done) {
-      fs.exists('vendor', function (exists) {
+      fs.exists('vendor', function(exists) {
         assert.ok(exists);
         done();
       });
@@ -17,7 +18,7 @@ describe('grunt', function() {
 
     // Ensure the build/html directory exists.
     it('it should create the build/html directory', function(done) {
-      fs.exists('build/html', function (exists) {
+      fs.exists('build/html', function(exists) {
         assert.ok(exists);
         done();
       });
@@ -26,113 +27,114 @@ describe('grunt', function() {
     // Ensure build/html/index.php exists and that index.php can be executed
     // with PHP.
     it('it should build a runnable Drupal docroot', function(done) {
-      fs.exists('build/html/index.php', function (exists) {
+      fs.exists('build/html/index.php', function(exists) {
         assert.ok(exists);
 
         if (exists) {
           process.chdir('build/html');
-          exec('php index.php', function (error, stdout, stderr) {
+          exec('php index.php', function(error) {
             var testDrupalRan = (error === null);
             process.chdir('../..');
             assert.ok(testDrupalRan, "Drupal's index.php could be executed with PHP");
             done();
           });
-        }
-        else {
+        } else {
           done();
         }
       });
     });
 
     // Ensure there is a symlink to src/modules.
-    var modulesSrc = (drupalCore == '8') ? '../../../src/modules' : '../../../../../src/modules',
-      modulesDest = (drupalCore == '8') ? 'build/html/modules/custom' : 'build/html/sites/all/modules/custom';
+    var modulesSrc = (drupalCore === '8') ? '../../../src/modules' : '../../../../../src/modules';
+    var modulesDest = (drupalCore === '8') ? 'build/html/modules/custom' : 'build/html/sites/all/modules/custom';
     it('it should link the ' + modulesDest + ' directory', function(done) {
-      fs.lstat(modulesDest, function (err, stats) {
+      fs.lstat(modulesDest, function(err, stats) {
+        assert.ok(!err);
         assert.ok(stats.isSymbolicLink());
 
         if (stats.isSymbolicLink()) {
-          fs.readlink(modulesDest, function (err, linkString) {
+          fs.readlink(modulesDest, function(err, linkString) {
+            assert.ok(!err);
             assert.equal(linkString, modulesSrc);
             done();
           });
-        }
-        else {
+        } else {
           done();
         }
       });
     });
 
     // Ensure there is a symlink for libs in src/libraries.
-    var librariesSrc = (drupalCore == '8') ? '../../../src/libraries' : '../../../../../src/libraries',
-      exampleLibSrc = librariesSrc + '/example_lib',
-      librariesDest = (drupalCore == '8') ? 'build/html/libraries' : 'build/html/sites/all/libraries',
-      exampleLibDest = librariesDest + '/example_lib';
+    var librariesSrc = (drupalCore === '8') ? '../../../src/libraries' : '../../../../../src/libraries';
+    var exampleLibSrc = librariesSrc + '/example_lib';
+    var librariesDest = (drupalCore === '8') ? 'build/html/libraries' : 'build/html/sites/all/libraries';
+    var exampleLibDest = librariesDest + '/example_lib';
     it('it should link libraries in the ' + librariesDest + ' directory', function(done) {
-      fs.lstat(exampleLibDest, function (err, stats) {
+      fs.lstat(exampleLibDest, function(err, stats) {
+        assert.ok(!err);
         assert.ok(stats.isSymbolicLink());
 
         if (stats.isSymbolicLink()) {
-          fs.readlink(exampleLibDest, function (err, linkString) {
+          fs.readlink(exampleLibDest, function(err, linkString) {
+            assert.ok(!err);
             assert.equal(linkString, exampleLibSrc);
             done();
           });
-        }
-        else {
+        } else {
           done();
         }
       });
     });
 
     // Ensure a custom library file is available under build.
-    var librariesBuildDest = (drupalCore == '8') ? 'build/html/libraries/example_lib/example.md' : 'build/html/sites/all/libraries/example_lib/example.md';
+    var librariesBuildDest = (drupalCore === '8') ? 'build/html/libraries/example_lib/example.md' : 'build/html/sites/all/libraries/example_lib/example.md';
     it('custom library file should exist in build', function(done) {
-      fs.exists(librariesBuildDest, function (exists) {
+      fs.exists(librariesBuildDest, function(exists) {
         assert.ok(exists);
         done();
       });
     });
 
     // Ensure a custom module file is available under build.
-    var modulesBuildDest = (drupalCore == '8') ? 'build/html/modules/custom/test.php' : 'build/html/sites/all/modules/custom/test.php';
+    var modulesBuildDest = (drupalCore === '8') ? 'build/html/modules/custom/test.php' : 'build/html/sites/all/modules/custom/test.php';
     it('custom module file should exist in build', function(done) {
-      fs.exists(modulesBuildDest, function (exists) {
+      fs.exists(modulesBuildDest, function(exists) {
         assert.ok(exists);
         done();
       });
     });
 
     // Ensure a custom theme file is available under build.
-    var themesBuildDest = (drupalCore == '8') ? 'build/html/themes/custom/example_theme/example_theme.info.yml' : 'build/html/sites/all/themes/custom/example_theme/example_theme.info';
+    var themesBuildDest = (drupalCore === '8') ? 'build/html/themes/custom/example_theme/example_theme.info.yml' : 'build/html/sites/all/themes/custom/example_theme/example_theme.info';
     it('custom theme file should exist in build', function(done) {
-      fs.exists(themesBuildDest, function (exists) {
+      fs.exists(themesBuildDest, function(exists) {
         assert.ok(exists);
         done();
       });
     });
 
     // Ensure a custom library file is available under package.
-    var librariesPackageDest = (drupalCore == '8') ? 'build/packages/package/libraries/example_lib/example.md' : 'build/packages/package/sites/all/libraries/example_lib/example.md';
+    var librariesPackageDest = (drupalCore === '8') ? 'build/packages/package/libraries/example_lib/example.md' : 'build/packages/package/sites/all/libraries/example_lib/example.md';
     it('custom library file should exist in package', function(done) {
-      fs.exists(librariesPackageDest, function (exists) {
+      fs.exists(librariesPackageDest, function(exists) {
         assert.ok(exists);
         done();
       });
     });
 
     // Ensure a custom module file is available under package.
-    var modulesPackageDest = (drupalCore == '8') ? 'build/packages/package/modules/custom/test.php' : 'build/packages/package/sites/all/modules/custom/test.php';
+    var modulesPackageDest = (drupalCore === '8') ? 'build/packages/package/modules/custom/test.php' : 'build/packages/package/sites/all/modules/custom/test.php';
     it('custom module file should exist in package', function(done) {
-      fs.exists(modulesPackageDest, function (exists) {
+      fs.exists(modulesPackageDest, function(exists) {
         assert.ok(exists);
         done();
       });
     });
 
     // Ensure a custom theme file is available under package.
-    var themesPackageDest = (drupalCore == '8') ? 'build/packages/package/themes/custom/example_theme/example_theme.info.yml' : 'build/packages/package/sites/all/themes/custom/example_theme/example_theme.info';
+    var themesPackageDest = (drupalCore === '8') ? 'build/packages/package/themes/custom/example_theme/example_theme.info.yml' : 'build/packages/package/sites/all/themes/custom/example_theme/example_theme.info';
     it('custom theme file should exist in package', function(done) {
-      fs.exists(themesPackageDest, function (exists) {
+      fs.exists(themesPackageDest, function(exists) {
         assert.ok(exists);
         done();
       });
@@ -141,7 +143,7 @@ describe('grunt', function() {
 
   describe('Script dispatching', function() {
     it('should pass commands along to themes', function(done) {
-      exec('grunt themes:example_theme:echo', function (error, stdout, stderr) {
+      exec('grunt themes:example_theme:echo', function(error, stdout) {
         var status = !error && stdout && stdout.match(/theme\sscripts\srun/)[0] && stdout.match(/run in example_theme/)[0];
         assert.ok(status);
         done();
@@ -149,7 +151,7 @@ describe('grunt', function() {
     });
 
     it('should run project operation scripts', function(done) {
-      exec('grunt echo', function (error, stdout, stderr) {
+      exec('grunt echo', function(error, stdout) {
         var status = !error && stdout && stdout.match(/operational\sscripts\srun/)[0];
         assert.ok(status);
         done();
@@ -157,7 +159,7 @@ describe('grunt', function() {
     });
 
     it('should run pre-op and post-op scripts', function(done) {
-      exec('grunt echo', function (error, stdout, stderr) {
+      exec('grunt echo', function(error, stdout) {
         var status = !error && stdout && stdout.match(/pre\-op script/)[0] && stdout.match(/post\-op script/)[0];
         assert.ok(status);
         done();
@@ -165,7 +167,7 @@ describe('grunt', function() {
     });
 
     it('should include project operation scripts in help output', function(done) {
-      exec('grunt help', function (error, stdout, stderr) {
+      exec('grunt help', function(error, stdout) {
         var status = !error && stdout && stdout.match(/Perform\sthe\sconfigured\s"echo"\stask/)[0];
         assert.ok(status);
         done();
@@ -175,7 +177,7 @@ describe('grunt', function() {
 
   describe('grunt task', function() {
     it('"git-setup" may be run to install git hooks.', function(done) {
-      exec('grunt git-setup', function(error, stdout, stderr) {
+      exec('grunt git-setup', function(error) {
         fs.exists('./.git/hooks/pre-commit', function(exists) {
           assert.ok(!error && exists);
           done();
@@ -188,15 +190,15 @@ describe('grunt', function() {
     // Package commands can take excessive time (> 10 minutes for D8).
     // Before testing them, remove the bulk of the Drupal codebase.
     before(function(done) {
-      fs.move('build/html/core', 'build/cache/core', function(err) {
-        fs.move('build/html/modules', 'build/cache/modules', function(err) {
+      fs.move('build/html/core', 'build/cache/core', function() {
+        fs.move('build/html/modules', 'build/cache/modules', function() {
           done();
         });
       });
     });
 
     it('should place the build codebase in build/packages/package by default', function(done) {
-      exec('grunt package', function(error, stdout, stderr) {
+      exec('grunt package', function(error) {
         fs.exists('build/packages/package/index.php', function(exists) {
           assert.ok(!error && exists);
           done();
@@ -205,7 +207,7 @@ describe('grunt', function() {
     });
 
     it('should allow override of grunt package destination with --name', function(done) {
-      exec('grunt package --name=upstream', function(error, stdout, stderr) {
+      exec('grunt package --name=upstream', function(error) {
         fs.exists('build/packages/upstream/index.php', function(exists) {
           assert.ok(!error && exists);
           done();
@@ -214,7 +216,7 @@ describe('grunt', function() {
     });
 
     it('should compress the package with grunt package:compress', function(done) {
-      exec('grunt package:compress --name=archive', function(error, stdout, stderr) {
+      exec('grunt package:compress --name=archive', function(error) {
         fs.exists('build/packages/archive.tgz', function(exists) {
           assert.ok(!error && exists);
           done();
@@ -231,8 +233,8 @@ describe('grunt', function() {
     });
 
     after(function(done) {
-      fs.move('build/cache/core', 'build/html/core', function(err) {
-        fs.move('build/cache/modules', 'build/html/modules', function(err) {
+      fs.move('build/cache/core', 'build/html/core', function() {
+        fs.move('build/cache/modules', 'build/html/modules', function() {
           done();
         });
       });

--- a/test/library.js
+++ b/test/library.js
@@ -1,3 +1,5 @@
+/* global describe, it */
+
 var assert = require('assert');
 var util = require('../lib/util');
 
@@ -9,16 +11,16 @@ describe('Utility Functions', function() {
     });
   });
   describe('provides a capability to construct absolute URLs', function() {
-    it ('allows expansion of a root path', function() {
+    it('allows expansion of a root path', function() {
       var items = util.expandUrls('http://example.com', ['/']);
       assert.equal('http://example.com/', items[0]);
     });
-    it ('allows expansion of multiple paths', function() {
+    it('allows expansion of multiple paths', function() {
       var items = util.expandUrls('http://example.com', ['/a', '/b']);
       assert.equal('http://example.com/a', items[0]);
       assert.equal('http://example.com/b', items[1]);
     });
-    it ('allows expansion of a base URL with a base path', function() {
+    it('allows expansion of a base URL with a base path', function() {
       var items = util.expandUrls('http://example.com/subsite', ['/a', '/b']);
       assert.equal('http://example.com/subsite/a', items[0]);
       assert.equal('http://example.com/subsite/b', items[1]);
@@ -32,20 +34,20 @@ describe('Initialization', function() {
   describe('of magic configuration', function() {
     it('should defer to the "GDT" namespace', function(done) {
       grunt.config.init({
-        config: { test_a: 'Enterprise' },
-        gdt: { test_a: 'Victory' }
+        config: {testA: 'Enterprise'},
+        gdt: {testA: 'Victory'}
       });
-      process.env['GDT_TEST_A'] = 'Yamaguchi';
+      process.env.GDT_TEST_A = 'Yamaguchi';
 
       var init = require('../lib/init')(grunt);
-      assert.equal(init.magic('test_a'), 'Victory');
+      assert.equal(init.magic('testA'), 'Victory');
       done();
     });
     it('should defer to environment over normal project configuration', function(done) {
       grunt.config.init({
-        config: { test_b: 'Enterprise' }
+        config: {testB: 'Enterprise'}
       });
-      process.env['GDT_TEST_B'] = 'Yamaguchi';
+      process.env.GDT_TEST_B = 'Yamaguchi';
 
       var init = require('../lib/init')(grunt);
       assert.equal(init.magic('test_b'), 'Yamaguchi');
@@ -53,35 +55,35 @@ describe('Initialization', function() {
     });
     it('should fall back to the project configuration', function(done) {
       grunt.config.init({
-        config: { test_c: 'Enterprise' }
+        config: {testC: 'Enterprise'}
       });
 
       var init = require('../lib/init')(grunt);
-      assert.equal(init.magic('test_c'), 'Enterprise');
+      assert.equal(init.magic('testC'), 'Enterprise');
       done();
     });
     it('should allow override of the environment variable name', function(done) {
       grunt.config.init({
-        config: { test_d: 'Enterprise' }
+        config: {testD: 'Enterprise'}
       });
-      process.env['GDT_TEST_DELTA'] = 'Yamaguchi';
+      process.env.GDT_TEST_DELTA = 'Yamaguchi';
 
       var init = require('../lib/init')(grunt);
-      assert.equal(init.magic('test_d', 'test_delta'), 'Yamaguchi');
+      assert.equal(init.magic('testD', 'test_delta'), 'Yamaguchi');
       done();
     });
     it('should allow override of the environment variable name without affecting priority', function(done) {
       grunt.config.init({
-        config: { test_e: 'Enterprise' }
+        config: {testE: 'Enterprise'}
       });
 
       var init = require('../lib/init')(grunt);
-      assert.equal(init.magic('test_e', 'test_epsilon'), 'Enterprise');
+      assert.equal(init.magic('testE', 'test_epsilon'), 'Enterprise');
       done();
     });
     it('should allow a nested value to be overridden', function(done) {
       grunt.config.init({
-        config: { nested: { item: 'a' } }
+        config: {nested: {item: 'a'}}
       });
 
       var init = require('../lib/init')(grunt);
@@ -89,5 +91,4 @@ describe('Initialization', function() {
       done();
     });
   });
-
 });


### PR DESCRIPTION
- Adding eslint configured to use the Google JavaScript standards. Excluding node_modules and test assets and output.
- Cleaning up code style in accordance with eslint/Google standard.
