### PR TITLE
Making binary paths configurable with defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Dropped support for Node.js v0.12 and earlier and PHP v5.4 and earlier.
 - Removed built-in support for Compass theme compilation and Ruby bundle
 installation.
+- Added configuration for the Behat binary path. Add default configuration for
+the paths of the phpcs, phpmd, and Drush binaries. Changed configuration key
+from `drush.cmd` to `drush.path` for consistency.
 - Updated dependencies.
 
 ### Upgrade Notes
@@ -14,6 +17,8 @@ Node.js v5.
 - PHP v5.5 or later is required.
 - Use of the built-in Compass theme compilation steps must be replaced by custom
 handling at the project- or theme-level.
+- Change the Gruntconfig.json configuration key `cmd` under `drush` to `path`,
+or if using the default path of `vendor/bin/drush`, remove the setting entirely.
 
 ## v0.11.1 [2016/04/17]
 

--- a/docs/10_BUILD.md
+++ b/docs/10_BUILD.md
@@ -199,7 +199,7 @@ This is an example of the settings for Drush tasks:
 ```
 {
   "drush": {
-    "cmd": "/usr/bin/drush",
+    "path": "/usr/bin/drush",
     "make": {
       "args": ["--force-complete", "--working-copy"]
     }
@@ -207,7 +207,7 @@ This is an example of the settings for Drush tasks:
 }
 ```
 
-**drush.cmd**: The path to the Drush executable that should be used for all
+**drush.path**: The path to the Drush executable that should be used for all
 Drush operations. If none is specified, the Drush executable found in the
 default PATH will be used.
 

--- a/docs/40_testing.md
+++ b/docs/40_testing.md
@@ -38,6 +38,7 @@ This is an example of the settings for Behat tasks:
 {
   "behat": {
     "flags": "--tags '~@javascript'",
+    "path": "/usr/local/bin/behat",
     "subsite": {
       "src": "./test/features/subsite/*.feature",
       "debug": false
@@ -55,3 +56,8 @@ should be used while invoking Behat. These flags can be overridden by using the
 `--behat-flags` option when running `grunt`. Common use cases are to include or
 exclude tests according to tags or to use an alternative profile defined in
 `behat.yml`.
+
+**behat.path**: A string with the path to the Behat executable. By default, this
+is set to `vendor/bin/behat` to use the version of Behat installed by Composer.
+Only set this option if you need to use a specific version of Behat that is
+installed elsewhere.

--- a/example/Gruntconfig.json
+++ b/example/Gruntconfig.json
@@ -11,15 +11,8 @@
     "srcFiles": ["!sites/*/files/**", "!xmlrpc.php", "!modules/php/*"],
     "projFiles": ["README*", "bin/**", "hooks/**", "src/*.make"]
   },
-  "phpcs": {
-    "path": "vendor/bin/phpcs"
-  },
-  "phpmd": {
-    "path": "vendor/bin/phpmd"
-  },
-  "drush": {
-    "cmd": "vendor/bin/drush"
-  },
+  "phpcs": true,
+  "phpmd": true,
   "behat": {
     "flags": "--tags ~@wip"
   },

--- a/lib/drupal.js
+++ b/lib/drupal.js
@@ -66,7 +66,7 @@ module.exports = function(grunt) {
   };
 
   module.drushPath = function() {
-    return grunt.config('config.drush.cmd') ? path.resolve(grunt.config('config.drush.cmd')) : 'drush';
+    return path.resolve(grunt.config('config.drush.path') || 'vendor/bin/drush');
   };
 
   module.loadDatabaseConnection = function(callback) {

--- a/tasks/behat.js
+++ b/tasks/behat.js
@@ -18,6 +18,7 @@ module.exports = function(grunt) {
    *     },
    *     "behat": {
    *       "flags": "--tags ~@wip",
+   *       "path": "/usr/local/bin/behat",
    *       "subsite": {
    *          "src": "./features/subsite/*.feature",
    *          "debug": false
@@ -36,6 +37,12 @@ module.exports = function(grunt) {
     for (var key in config.siteUrls) {
       if (config.siteUrls.hasOwnProperty(key)) {
         var options = {};
+        var path = 'vendor/bin/behat';
+
+        // Allow configuring the path to the behat binary.
+        if (config.behat && config.behat.path) {
+          path = config.behat.path;
+        }
 
         // Check for per-site behat options.
         if (config.behat && config.behat[key]) {
@@ -59,7 +66,7 @@ module.exports = function(grunt) {
             options: _.extend({
               config: './test/behat.yml',
               maxProcesses: 5,
-              bin: 'vendor/bin/behat',
+              bin: path,
               debug: true,
               env: _.extend({}, process.env, {
                 BEHAT_PARAMS: "{\"extensions\": {\"Drupal\\\\DrupalExtension\": {\"drupal\": {\"drupal_root\": \"./" + config.buildPaths.html + "\"}}, \"Behat\\\\MinkExtension\": {\"base_url\": \"" + config.siteUrls[key] + "\", \"zombie\": {\"node_modules_path\": \"" + process.cwd() + "/node_modules/\"}}}}"

--- a/test/test_assets/Gruntconfig.json
+++ b/test/test_assets/Gruntconfig.json
@@ -10,15 +10,8 @@
     "srcFiles": ["!sites/*/files/**", "!xmlrpc.php", "!modules/php/*"],
     "projFiles": ["README*", "bin/**"]
   },
-  "phpcs": {
-    "path": "vendor/bin/phpcs"
-  },
-  "phpmd": {
-    "path": "vendor/bin/phpmd"
-  },
-  "drush": {
-    "cmd": "vendor/bin/drush"
-  },
+  "phpcs": true,
+  "phpmd": true,
   "behat": {
     "flags": "--tags ~@wip"
   },

--- a/test/test_assets_d8/Gruntconfig.json
+++ b/test/test_assets_d8/Gruntconfig.json
@@ -11,15 +11,8 @@
     "srcFiles": ["!sites/*/files/**", "!xmlrpc.php", "!modules/php/*"],
     "projFiles": ["README*", "bin/**"]
   },
-  "phpcs": {
-    "path": "vendor/bin/phpcs"
-  },
-  "phpmd": {
-    "path": "vendor/bin/phpmd"
-  },
-  "drush": {
-    "cmd": "vendor/bin/drush"
-  },
+  "phpcs": true,
+  "phpmd": true,
   "behat": {
     "flags": "--tags ~@wip"
   },


### PR DESCRIPTION
- Exposing binary paths (phpcs, phpmd, drush, behat) as configuration options in Gruntconfig.json.
- Adding default values for Composer-installed dependencies.

Resolves #102. Also relates to #169 and #30.
