### PR TITLE
Remove unneeded call to drupal-scaffold.

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -60,7 +60,6 @@ module.exports = function(grunt) {
   tasksDefault.push('scaffold');
 
   if (grunt.file.exists('./composer.lock') && grunt.config.get(['composer', 'install'])) {
-    // Manually run `composer drupal-scaffold` since this is only automatically run on update.
     // Run `composer install` if there is already a lock file. Updates should be explicit once this file exists.
     tasksDefault.unshift('composer:install');
   } else if (grunt.config.get(['composer', 'update'])) {

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -61,7 +61,6 @@ module.exports = function(grunt) {
 
   if (grunt.file.exists('./composer.lock') && grunt.config.get(['composer', 'install'])) {
     // Manually run `composer drupal-scaffold` since this is only automatically run on update.
-    tasksDefault.unshift('composer:drupal-scaffold');
     // Run `composer install` if there is already a lock file. Updates should be explicit once this file exists.
     tasksDefault.unshift('composer:install');
   } else if (grunt.config.get(['composer', 'update'])) {


### PR DESCRIPTION
There is an unneeded call to composer:drupal-scaffold in the bootstrap.js file. Scaffold is called regardless of if a composer install or composer update is called.