### PR TITLE
Conditionally run composer:drupal-scaffold.

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -60,8 +60,10 @@ module.exports = function(grunt) {
   tasksDefault.push('scaffold');
 
   if (grunt.file.exists('./composer.lock') && grunt.config.get(['composer', 'install'])) {
-    // Manually run `composer drupal-scaffold` since this is only automatically run on update.
-    tasksDefault.unshift('composer:drupal-scaffold');
+    if (grunt.task.exists('composer:drupal-scaffold')) {
+      // Manually run `composer drupal-scaffold` since this is only automatically run on update.
+      tasksDefault.unshift('composer:drupal-scaffold');
+    }
     // Run `composer install` if there is already a lock file. Updates should be explicit once this file exists.
     tasksDefault.unshift('composer:install');
   } else if (grunt.config.get(['composer', 'update'])) {

--- a/tasks/composer.js
+++ b/tasks/composer.js
@@ -5,7 +5,6 @@ module.exports = function(grunt) {
    * Dynamically adds a Composer install task if a composer.json file
    * exists in the project directory.
    */
-
   if (require('fs').existsSync('./composer.json')) {
     grunt.loadNpmTasks('grunt-composer');
     var Help = require('../lib/help')(grunt);
@@ -28,7 +27,12 @@ module.exports = function(grunt) {
         ]
       }
     });
-    grunt.config(['composer', 'drupal-scaffold'], {});
+
+    // Add the drupal-scaffold task if it is defined in the `composer.json`.
+    var composer = require('fs').readFileSync('./composer.json', 'utf8');
+    if (typeof composer.scripts !== 'undefined' && 'drupal-scaffold' in composer.scripts) {
+      grunt.config(['composer', 'drupal-scaffold'], {});
+    }
 
     Help.add({
       task: 'composer',


### PR DESCRIPTION
- Only run the `composer:drupal-scaffold` task if it is defined in the
  `composer.json` scripts section.

This fixes an issue where D7 builds (or D8  builds without the `drupal-scaffold` script defined) would fail with:

```
  [Symfony\Component\Console\Exception\CommandNotFoundException]
  Command "drupal-scaffold" is not defined.


Warning: Task "composer:drupal-scaffold" failed. Use --force to continue.

Aborted due to warnings.
```