### PR TITLE
Fixes missing composer:drupal-scaffold command.

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -60,7 +60,7 @@ module.exports = function(grunt) {
   tasksDefault.push('scaffold');
 
   if (grunt.file.exists('./composer.lock') && grunt.config.get(['composer', 'install'])) {
-    if (grunt.task.exists('composer:drupal-scaffold')) {
+    if (grunt.config.get(['composer', 'drupal-scaffold'])) {
       // Manually run `composer drupal-scaffold` since this is only automatically run on update.
       tasksDefault.unshift('composer:drupal-scaffold');
     }

--- a/tasks/composer.js
+++ b/tasks/composer.js
@@ -29,7 +29,7 @@ module.exports = function(grunt) {
     });
 
     // Add the drupal-scaffold task if it is defined in the `composer.json`.
-    var composer = require('fs').readFileSync('./composer.json', 'utf8');
+    var composer = JSON.parse(require('fs').readFileSync('./composer.json', 'utf8'));
     if (typeof composer.scripts !== 'undefined' && 'drupal-scaffold' in composer.scripts) {
       grunt.config(['composer', 'drupal-scaffold'], {});
     }


### PR DESCRIPTION
- Under certain conditions, the raw `composer.json` is not evaluated as
  JSON, so explicitly parse the file.
- The `grunt.task.exists` command wasn't working under certain
  conditions, so `grunt.config.get` is used instead.