### PR TITLE
Updates to feature/package_rewrite_composer

### DIFF
--- a/example/Gruntconfig.json
+++ b/example/Gruntconfig.json
@@ -11,7 +11,7 @@
     "srcFiles": ["!sites/*/files/**", "!xmlrpc.php", "!modules/php/*"],
     "projFiles": ["README*", "bin/**", "hooks/**", "src/*.make", "vendor/**"],
     "dest": {
-      "docroot": "build/html",
+      "docroot": "html",
       "devResources": ""
     }
   },

--- a/tasks/package.js
+++ b/tasks/package.js
@@ -19,7 +19,7 @@ module.exports = function(grunt) {
       var destPath = grunt.option('package-dest');
       var composer = grunt.file.readJSON(destPath + '/composer.json');
       // Determine new installer-paths
-      var pathInstall = pathPackage + '/';
+      var pathInstall = pathPackage ? pathPackage + '/' : '';
       if (pathVendor) {
         // Make sure install path is relative to vendor location.
         var regexVendor = new RegExp('^' + pathVendor + '/');
@@ -28,7 +28,7 @@ module.exports = function(grunt) {
       var regex = new RegExp('^' + pathBuild + '/');
       for (var key in composer.extra['installer-paths']) {
         // Add an unnecessary if check just for eslint rules.
-        if (composer.extra['installer-paths'][key]) {
+        if (composer.extra['installer-paths'].hasOwnProperty(key)) {
           var newKey = key.replace(regex, pathInstall);
           if (newKey !== key) {
             // Alter keys in `extra.installer-paths` object to change `build/html`
@@ -48,7 +48,7 @@ module.exports = function(grunt) {
       if (pathVendor) {
         // Remove the original file if we moved it.
         grunt.file.delete(destPath + '/composer.json');
-        // Change working directory for composer install.
+        // Change working directory for later `composer install`.
         grunt.config(['composer'], {
           options: {
             flags: ['no-dev'],
@@ -113,6 +113,8 @@ module.exports = function(grunt) {
         }
       });
       tasks.push('composer:install');
+      grunt.config(['composer', 'drupal-scaffold'], {});
+      tasks.push('composer:drupal-scaffold');
     }
 
     if (this.args[0] && this.args[0] === 'compress') {

--- a/test/build.js
+++ b/test/build.js
@@ -114,7 +114,7 @@ describe('grunt', function() {
     });
 
     // Ensure a custom library file is available under package.
-    var librariesPackageDest = (drupalCore === '8') ? 'build/packages/package/build/html/libraries/example_lib/example.md' : 'build/packages/package/sites/all/libraries/example_lib/example.md';
+    var librariesPackageDest = (drupalCore === '8') ? 'build/packages/package/html/libraries/example_lib/example.md' : 'build/packages/package/sites/all/libraries/example_lib/example.md';
     it('custom library file should exist in package', function(done) {
       fs.exists(librariesPackageDest, function(exists) {
         assert.ok(exists);
@@ -123,7 +123,7 @@ describe('grunt', function() {
     });
 
     // Ensure a custom module file is available under package.
-    var modulesPackageDest = (drupalCore === '8') ? 'build/packages/package/build/html/modules/custom/test.php' : 'build/packages/package/sites/all/modules/custom/test.php';
+    var modulesPackageDest = (drupalCore === '8') ? 'build/packages/package/html/modules/custom/test.php' : 'build/packages/package/sites/all/modules/custom/test.php';
     it('custom module file should exist in package', function(done) {
       fs.exists(modulesPackageDest, function(exists) {
         assert.ok(exists);
@@ -132,7 +132,7 @@ describe('grunt', function() {
     });
 
     // Ensure a custom theme file is available under package.
-    var themesPackageDest = (drupalCore === '8') ? 'build/packages/package/build/html/themes/custom/example_theme/example_theme.info.yml' : 'build/packages/package/sites/all/themes/custom/example_theme/example_theme.info';
+    var themesPackageDest = (drupalCore === '8') ? 'build/packages/package/html/themes/custom/example_theme/example_theme.info.yml' : 'build/packages/package/sites/all/themes/custom/example_theme/example_theme.info';
     it('custom theme file should exist in package', function(done) {
       fs.exists(themesPackageDest, function(exists) {
         assert.ok(exists);

--- a/test/build.js
+++ b/test/build.js
@@ -202,7 +202,7 @@ describe('grunt', function() {
     it('should place the build codebase in build/packages/package by default', function(done) {
       this.timeout(180000);
       exec('grunt package', function(error) {
-        var indexPackageDest = (drupalCore === '8') ? 'build/packages/package/build/html/index.php' : 'build/packages/package/index.php';
+        var indexPackageDest = (drupalCore === '8') ? 'build/packages/package/html/index.php' : 'build/packages/package/index.php';
         fs.exists(indexPackageDest, function(exists) {
           assert.ok(!error && exists);
           done();
@@ -213,7 +213,7 @@ describe('grunt', function() {
     it('should allow override of grunt package destination with --name', function(done) {
       this.timeout(180000);
       exec('grunt package --name=upstream', function(error) {
-        var indexPackageDest = (drupalCore === '8') ? 'build/packages/upstream/build/html/index.php' : 'build/packages/upstream/index.php';
+        var indexPackageDest = (drupalCore === '8') ? 'build/packages/upstream/html/index.php' : 'build/packages/upstream/index.php';
         fs.exists(indexPackageDest, function(exists) {
           assert.ok(!error && exists);
           done();

--- a/test/test_assets_d8/Gruntconfig.json
+++ b/test/test_assets_d8/Gruntconfig.json
@@ -10,7 +10,7 @@
     "srcFiles": ["!sites/*/files/**", "!xmlrpc.php", "!modules/php/*"],
     "projFiles": ["README*", "bin/**", "hooks/**", "src/*.make", "vendor/**", "composer.*"],
     "dest": {
-      "docroot": "build/html",
+      "docroot": "html",
       "devResources": ""
     }
   },


### PR DESCRIPTION
Updates to feature/package_rewrite_composer:
- Regenerates Drupal docroot autoload.php if needed
- Allow packages.dest configuration to be optional
- Changes example and test configuration's package docroot dest to "html" so package directory should include "html" (docroot), vendor, composer.json, composer.lock

@mike-potter Please review these changes against #297.
