### PR TITLE
Fix error when disabling eslint or phpcs

### DIFF
--- a/tasks/quality.js
+++ b/tasks/quality.js
@@ -182,7 +182,7 @@ module.exports = function(grunt) {
   grunt.registerTask('validate', 'Validate the quality of custom code.', function(mode) {
     phpcsConfig = grunt.config.get('phpcs');
     var files;
-    if (phpcsConfig.validate) {
+    if (phpcsConfig && phpcsConfig.validate) {
       files = filesToProcess(phpcsConfig.validate.src);
       if (files.length) {
         grunt.config.set('phpcs.validate.src', files);
@@ -192,7 +192,7 @@ module.exports = function(grunt) {
     eslintConfig = grunt.config.get('eslint');
     var eslintIgnoreError = grunt.config.get('config.validate.ignoreError') === undefined ? false : grunt.config.get('config.validate.ignoreError');
     var eslintName = eslintIgnoreError ? 'force:eslint' : 'eslint';
-    if (eslintConfig.validate) {
+    if (eslintConfig && eslintConfig.validate) {
       files = filesToProcess(eslintConfig.validate);
       if (files.length) {
         grunt.config.set('eslint.validate', files);


### PR DESCRIPTION
Adding check that phpcsConfig and eslintConfig are defined to prevent an error that aborts the job if these settings are not defined in Gruntconfig.json.

Currently, if phpcsConfig or eslintConfig are excluded from the Gruntconfig.json file, the validate task fails with:
```
Running "validate" task
Warning: Cannot read property 'validate' of undefined Use --force to continue.

Aborted due to warnings.
```

It should be possible to disable phpcs or eslint by setting phpcsConfig or eslintConfig to false to excluding them entirely.
