### PR TITLE
Add options to package task to exclude paths such as node_modules and…

### DIFF
--- a/tasks/package.js
+++ b/tasks/package.js
@@ -69,12 +69,12 @@ module.exports = function(grunt) {
     var exclude = grunt.config('config.packages.exclude');
     if (exclude !== false) {
       var excludePaths = grunt.config('config.packages.excludePaths');
-      if (!excludePaths || excludePaths.length == 0) {
+      if (!excludePaths || !excludePaths) {
         excludePaths = ['bower_components', 'node_modules'];
       }
 
-      for (var key in excludePaths) {
-        excludePaths[key] = '!**/' + excludePaths[key] + '/**';
+      for (var i = 0; i < excludePaths.length; i++) {
+        excludePaths[i] = '!**/' + excludePaths[i] + '/**';
       }
       srcFiles = srcFiles.concat(excludePaths);
       projFiles = projFiles.concat(excludePaths);

--- a/tasks/package.js
+++ b/tasks/package.js
@@ -66,6 +66,20 @@ module.exports = function(grunt) {
     var srcFiles = ['**', '!**/.gitkeep'].concat((config && config.srcFiles && config.srcFiles.length) ? config.srcFiles : '**');
     var projFiles = (config && config.projFiles && config.projFiles.length) ? config.projFiles : [];
 
+    var exclude = grunt.config('config.packages.exclude');
+    if (exclude !== false) {
+      var excludePaths = grunt.config('config.packages.excludePaths');
+      if (!excludePaths || excludePaths.length == 0) {
+        excludePaths = ['bower_components', 'node_modules'];
+      }
+
+      for (var key in excludePaths) {
+        excludePaths[key] = '!**/' + excludePaths[key] + '/**';
+      }
+      srcFiles = srcFiles.concat(excludePaths);
+      projFiles = projFiles.concat(excludePaths);
+    }
+
     // Look for a package target spec, build destination path.
     var packageName = grunt.option('name') || config.name || 'package';
     var destPath = grunt.config.get('config.buildPaths.packages') + '/' + packageName;


### PR DESCRIPTION
Several projects using Pattern lab are having bad performance issues when using the "grunt package" command.  This PR adds an option "config.packages.exclude" (default TRUE) that will exclude additional folders specified in "config.packages.excludePaths".  If "config.packages.excludePaths" is empty, a default of ["node_modules", "bower_components"] is used.

While the existing "config.packages.srcFiles" and "config.packages.projFiles" allow you to add specific files and paths to be excluded, the "config.packages.excludePaths" is designed for folders and is applied to both srcFiles and projFiles and has the useful default paths.

A further performance improvement would be to use rsync instead of grunt-contrib-copy, but delaying that till post 1.0 release.