### PR TITLE
Add rsync option to package command and improve performance

### DIFF
--- a/tasks/package.js
+++ b/tasks/package.js
@@ -61,17 +61,10 @@ module.exports = function(grunt) {
 
   grunt.registerTask('package', 'Package the operational codebase for deployment. Use package:compress to create an archive.', function() {
     grunt.loadNpmTasks('grunt-contrib-copy');
-    grunt.loadNpmTasks('grunt-shell');
 
     var config = grunt.config.get('config.packages');
     var srcFiles = ['**', '!**/.gitkeep'].concat((config && config.srcFiles && config.srcFiles.length) ? config.srcFiles : '**');
     var projFiles = (config && config.projFiles && config.projFiles.length) ? config.projFiles : [];
-
-    // Look for a package target spec, build destination path.
-    var packageName = grunt.option('name') || config.name || 'package';
-    var destPath = grunt.config.get('config.buildPaths.packages') + '/' + packageName;
-    var tasks = [];
-    grunt.option('package-dest', destPath);
 
     var exclude = grunt.config('config.packages.exclude');
     if (exclude !== false) {
@@ -83,50 +76,44 @@ module.exports = function(grunt) {
       for (var i = 0; i < excludePaths.length; i++) {
         excludePaths[i] = '!**/' + excludePaths[i] + '/**';
       }
-      //srcFiles = srcFiles.concat(excludePaths);
-      //projFiles = projFiles.concat(excludePaths);
+      srcFiles = srcFiles.concat(excludePaths);
+      projFiles = projFiles.concat(excludePaths);
     }
 
-    var rsync = 'rsync -a '
-        + '--exclude node_modules '
-        + '--exclude bower_components '
-        + '--exclude .git '
-        + '--exclude sites/*/files '
-        + '--exclude xmlrpc.php ';
+    // Look for a package target spec, build destination path.
+    var packageName = grunt.option('name') || config.name || 'package';
+    var destPath = grunt.config.get('config.buildPaths.packages') + '/' + packageName;
+    var tasks = [];
+    grunt.option('package-dest', destPath);
 
-    var srcPath = grunt.config('config.buildPaths.html');
-    var destSrc = path.resolve(destPath, grunt.config.get('config.packages.dest.docroot') || '');
-    var command = rsync + srcPath + '/ ' + destSrc + '/';
-    console.log(command);
-    console.log(destSrc)
-    grunt.config('shell.mkSrc', {
-      command: 'mkdir -p ' + destSrc
+    grunt.config('copy.package', {
+      files: [
+        {
+          expand: true,
+          cwd: '<%= config.buildPaths.html %>',
+          src: srcFiles,
+          dest: path.resolve(destPath, grunt.config.get('config.packages.dest.docroot') || ''),
+          dot: true,
+          follow: true
+        },
+        {
+          expand: true,
+          src: projFiles,
+          dest: path.resolve(destPath, grunt.config.get('config.packages.dest.devResources') || ''),
+          dot: true,
+          follow: true
+        }
+      ],
+      options: {
+        gruntLogHeader: false,
+        mode: true
+      }
     });
-    grunt.config('shell.srcFiles', {
-      command: command
-    });
-
-    var destProj = path.resolve(destPath, grunt.config.get('config.packages.dest.devResources') || '');
-    grunt.config('shell.mkProj', {
-      command: 'mkdir -p ' + destProj
-    });
-    for (var i = 0; i < projFiles.length; i++) {
-      var command = rsync + srcPath + '/' + projFiles[i] + ' ' + destProj;
-      console.log(command);
-      grunt.config('shell.projFiles' + i, {
-        command: command
-      });
-    }
 
     grunt.config.set('clean.packages', [destPath]);
 
     tasks.push('clean:packages');
-    tasks.push('shell:mkSrc');
-    tasks.push('shell:srcFiles');
-    tasks.push('shell:mkProj');
-    for (var i = 0; i < projFiles.length; i++) {
-      tasks.push('shell:projFiles' + i);
-    }
+    tasks.push('copy:package');
 
     // If the `composer.json` file is being packaged, rebuild composer dependencies without dev.
     if (projFiles.find(function(pattern) {

--- a/tasks/package.js
+++ b/tasks/package.js
@@ -69,12 +69,12 @@ module.exports = function(grunt) {
     var exclude = grunt.config('config.packages.exclude');
     if (exclude !== false) {
       var excludePaths = grunt.config('config.packages.excludePaths');
-      if (!excludePaths || excludePaths.length == 0) {
+      if (!excludePaths || !excludePaths) {
         excludePaths = ['bower_components', 'node_modules'];
       }
 
-      for (var key in excludePaths) {
-        excludePaths[key] = '!**/' + excludePaths[key] + '/**';
+      for (var i = 0; i < excludePaths.length; i++) {
+        excludePaths[i] = '!**/' + excludePaths[i] + '/**';
       }
       srcFiles = srcFiles.concat(excludePaths);
       projFiles = projFiles.concat(excludePaths);

--- a/tasks/package.js
+++ b/tasks/package.js
@@ -66,6 +66,20 @@ module.exports = function(grunt) {
     var srcFiles = ['**', '!**/.gitkeep'].concat((config && config.srcFiles && config.srcFiles.length) ? config.srcFiles : '**');
     var projFiles = (config && config.projFiles && config.projFiles.length) ? config.projFiles : [];
 
+    var exclude = grunt.config('config.packages.exclude');
+    if (exclude !== false) {
+      var excludePaths = grunt.config('config.packages.excludePaths');
+      if (!excludePaths || excludePaths.length == 0) {
+        excludePaths = ['bower_components', 'node_modules'];
+      }
+
+      for (var key in excludePaths) {
+        excludePaths[key] = '!**/' + excludePaths[key] + '/**';
+      }
+      srcFiles = srcFiles.concat(excludePaths);
+      projFiles = projFiles.concat(excludePaths);
+    }
+
     // Look for a package target spec, build destination path.
     var packageName = grunt.option('name') || config.name || 'package';
     var destPath = grunt.config.get('config.buildPaths.packages') + '/' + packageName;


### PR DESCRIPTION
This is a fairly significant patch, but should not affect existing projects.  It adds a "packages.rsync" option (False by default).  When set to true, the package will be generated in a separate folder (packages.vmData defaults to "build/vm_data") via rsync and the compress option is enabled to generate an archive from the package, which is moved to the normal build/packages destination.

By mounting build/vm_data into the VM in your docker_composer.yml file, this allows the package to be built directly to the VM bypassing NFS to the local filesystem.  Only the final archive.tgz is moved into the local file system.  The vmData persists so the Build container can still perform additional tasks as needed, such as pushing the package into a remote repo.  Or, the local tgz archive can be used to deploy the package.

On a current real project, this reduced the normal "grunt package" command running from the build container from a 40-minute task, down to a TWO minute task.

Given the significant performance improvement, I'm marking this PR for Milestone 1, so let's get reviews of this approach.  (FYI it was modeled from some code in a "grunt deploy" task written for another project by Adam)