### PR TITLE
Ensure profile, modules, libraries directories exist

### DIFF
--- a/tasks/scaffold.js
+++ b/tasks/scaffold.js
@@ -43,7 +43,6 @@ module.exports = function(grunt) {
           src: '<%= config.srcPaths.drupal %>/modules',
           dest: path.join(drupal.modulePath(), 'custom')
         });
-        console.log("Profile: ",drupal.profilePath());
         grunt.config(['symlink', 'profiles'], {
           expand: true,
           cwd: '<%= config.srcPaths.drupal %>/profiles',

--- a/tasks/scaffold.js
+++ b/tasks/scaffold.js
@@ -23,6 +23,16 @@ module.exports = function(grunt) {
 
         grunt.loadNpmTasks('grunt-contrib-symlink');
 
+        grunt.config.set('mkdir.drupal', {
+          options: {
+            create: [
+              drupal.libraryPath(),
+              drupal.modulePath(),
+              drupal.profilePath()
+            ]
+          }
+        });
+
         grunt.config(['symlink', 'libraries'], {
           expand: true,
           cwd: '<%= config.srcPaths.drupal %>/libraries',
@@ -33,6 +43,7 @@ module.exports = function(grunt) {
           src: '<%= config.srcPaths.drupal %>/modules',
           dest: path.join(drupal.modulePath(), 'custom')
         });
+        console.log("Profile: ",drupal.profilePath());
         grunt.config(['symlink', 'profiles'], {
           expand: true,
           cwd: '<%= config.srcPaths.drupal %>/profiles',
@@ -55,6 +66,7 @@ module.exports = function(grunt) {
         });
 
         grunt.task.run([
+          'mkdir:drupal',
           'symlink:profiles',
           'symlink:libraries',
           'symlink:modules',


### PR DESCRIPTION
This is a fix for https://github.com/phase2/grunt-drupal-tasks/issues/304.  In Drupal 8.2 it requires the existence of the modules, libraries, profiles folders.  If there isn't any corresponding folder in /src, these top level folders were not getting created.