### PR TITLE
Expose eslint/phpcs report format config

### DIFF
--- a/tasks/quality.js
+++ b/tasks/quality.js
@@ -95,7 +95,7 @@ module.exports = function(grunt) {
         bin: '<%= config.phpcs.path %>',
         standard: phpStandard,
         ignoreExitCode: ignoreError,
-        report: 'checkstyle',
+        report: phpcsConfig.format || 'checkstyle',
         reportFile: '<%= config.buildPaths.reports %>/phpcs.xml'
       }
     });
@@ -138,7 +138,7 @@ module.exports = function(grunt) {
       validate: eslintTarget,
       analyze: {
         options: {
-          format: 'checkstyle',
+          format: eslintConfig.format || 'checkstyle',
           outputFile: '<%= config.buildPaths.reports %>/eslint.xml'
         },
         src: eslintTarget


### PR DESCRIPTION
Hey there,

This makes the PHPCS/ESLint report format overridable through the Grunt options. In our case, our CI tool uses JUnit for report parsing.

Let me know if this needs anything else. Thanks!