### PR TITLE
Allow task-specific Composer arguments and apply defaults

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -62,13 +62,13 @@ module.exports = function(grunt) {
   if (grunt.file.exists('./composer.lock') && grunt.config.get(['composer', 'install'])) {
     if (grunt.config.get(['composer', 'drupal-scaffold'])) {
       // Manually run `composer drupal-scaffold` since this is only automatically run on update.
-      tasksDefault.unshift('composer:drupal-scaffold');
+      tasksDefault.unshift('composer:drupal-scaffold:drupal-scaffold');
     }
     // Run `composer install` if there is already a lock file. Updates should be explicit once this file exists.
-    tasksDefault.unshift('composer:install');
+    tasksDefault.unshift('composer:install:install');
   } else if (grunt.config.get(['composer', 'update'])) {
     // Run `composer update` if no lock file exists. This forces `composer drupal-scaffold` to run.
-    tasksDefault.unshift('composer:update');
+    tasksDefault.unshift('composer:update:update');
   }
 
   if (grunt.task.exists('compile-theme')) {

--- a/tasks/composer.js
+++ b/tasks/composer.js
@@ -6,27 +6,30 @@ module.exports = function(grunt) {
    * exists in the project directory.
    */
   if (require('fs').existsSync('./composer.json')) {
-    grunt.loadNpmTasks('grunt-composer');
     var Help = require('../lib/help')(grunt);
 
-    grunt.config(['composer', 'install'], {
-      options: {
-        flags: [
-          'no-interaction',
-          'no-progress',
-          'prefer-dist'
-        ]
+    grunt.config('composer', {
+      install: {
+        options: {
+          flags: [
+            'no-interaction',
+            'no-progress',
+            'prefer-dist'
+          ]
+        }
+      },
+      update: {
+        options: {
+          flags: [
+            'no-interaction',
+            'no-progress',
+            'prefer-dist'
+          ]
+        }
       }
     });
-    grunt.config(['composer', 'update'], {
-      options: {
-        flags: [
-          'no-interaction',
-          'no-progress',
-          'prefer-dist'
-        ]
-      }
-    });
+
+    grunt.loadNpmTasks('grunt-composer');
 
     // Add the drupal-scaffold task if it is defined in the `composer.json`.
     var composer = JSON.parse(require('fs').readFileSync('./composer.json', 'utf8'));


### PR DESCRIPTION
This fixes #319.

Changes:
- Initializes grunt-composer after configuration to enable multi task mode and task-specific configuration.
- Updates default tasks for multi task mode.

At this point, this has a potential breaking change, since the Grunt commands `composer:install` and `composer:update` no longer work and must be changed to `composer:install:install` and `composer:update:update`.
