### PR TITLE
Allow the use of separate files for configuration

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -1,6 +1,6 @@
 module.exports = function(grunt) {
   // Initialize global configuration variables.
-  var config = grunt.file.readJSON('Gruntconfig.json');
+  var config = require('load-grunt-configs')(grunt);
   if (grunt.config.getRaw() === undefined) {
     grunt.initConfig({
       config: config

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -1,12 +1,32 @@
 module.exports = function(grunt) {
   // Initialize global configuration variables.
-  var config = require('load-grunt-configs')(grunt);
+  var config = grunt.file.readJSON('Gruntconfig.json');
   if (grunt.config.getRaw() === undefined) {
     grunt.initConfig({
       config: config
     });
   } else {
     grunt.config.set('config', config);
+  }
+
+  config_dir = grunt.config.get('config.srcPaths.config_dir');
+  if (config_dir && grunt.file.isDir(config_dir)) {
+    var options = {
+      config: {
+        src: [
+          config_dir + '/*.js*',
+          config_dir + '/*.coffee',
+          config_dir + '/*.y*ml',
+          config_dir + '/*.cson'
+        ]
+      }
+    };
+    var configs = require('load-grunt-configs')(grunt, options);
+    for (config_name in configs) {
+      if (config_name != 'config') {
+        grunt.config.set('config.' + config_name, configs[config_name]);
+      }
+    }
   }
 
   var GDT = require('./lib/init')(grunt);

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -9,22 +9,22 @@ module.exports = function(grunt) {
     grunt.config.set('config', config);
   }
 
-  config_dir = grunt.config.get('config.srcPaths.config_dir');
-  if (config_dir && grunt.file.isDir(config_dir)) {
+  var configDir = grunt.config.get('config.srcPaths.configDir');
+  if (configDir && grunt.file.isDir(configDir)) {
     var options = {
       config: {
         src: [
-          config_dir + '/*.js*',
-          config_dir + '/*.coffee',
-          config_dir + '/*.y*ml',
-          config_dir + '/*.cson'
+          configDir + '/*.js*',
+          configDir + '/*.coffee',
+          configDir + '/*.y*ml',
+          configDir + '/*.cson'
         ]
       }
     };
     var configs = require('load-grunt-configs')(grunt, options);
-    for (config_name in configs) {
-      if (config_name != 'config') {
-        grunt.config.set('config.' + config_name, configs[config_name]);
+    for (var configName in configs) {
+      if (configName !== 'config') {
+        grunt.config.set('config.' + configName, configs[configName]);
       }
     }
   }

--- a/docs/10_BUILD.md
+++ b/docs/10_BUILD.md
@@ -154,6 +154,11 @@ The following build output paths are optional to specify in the project's
 **srcPaths.make**: The Drush make file used to assemble the Drupal project.
 This is only used for Drupal 7.x projects.  Example is `src/project.make`.
 
+**srcPaths.config_dir**: The directory that should be used for loading
+configurations. The files inside this directory will be loaded using
+[load-grunt-configs](https://www.npmjs.com/package/load-grunt-configs)
+and merged with the *Gruntconfig.json*.
+
 **buildPaths.build**: The directory that should be used for miscellaneous build
 artifacts. This can be the parent directory of the following build paths.
 

--- a/docs/10_BUILD.md
+++ b/docs/10_BUILD.md
@@ -154,7 +154,7 @@ The following build output paths are optional to specify in the project's
 **srcPaths.make**: The Drush make file used to assemble the Drupal project.
 This is only used for Drupal 7.x projects.  Example is `src/project.make`.
 
-**srcPaths.config_dir**: The directory that should be used for loading
+**srcPaths.configDir**: The directory that should be used for loading
 configurations. The files inside this directory will be loaded using
 [load-grunt-configs](https://www.npmjs.com/package/load-grunt-configs)
 and merged with the *Gruntconfig.json*.

--- a/example/Gruntconfig.json
+++ b/example/Gruntconfig.json
@@ -1,19 +1,12 @@
 {
   "srcPaths": {
+    "config_dir": "config",
     "make": "src/project.make",
     "drupal": "src"
   },
   "domain": "project.vm",
   "buildPaths": {
     "packages": "build/packages"
-  },
-  "packages": {
-    "srcFiles": ["!sites/*/files/**", "!xmlrpc.php", "!modules/php/*"],
-    "projFiles": ["README*", "bin/**", "hooks/**", "src/*.make", "vendor/**"],
-    "dest": {
-      "docroot": "html",
-      "devResources": ""
-    }
   },
   "phpcs": true,
   "phpmd": true,

--- a/example/Gruntconfig.json
+++ b/example/Gruntconfig.json
@@ -1,6 +1,6 @@
 {
   "srcPaths": {
-    "config_dir": "config",
+    "configDir": "config",
     "make": "src/project.make",
     "drupal": "src"
   },

--- a/example/config/packages.yml
+++ b/example/config/packages.yml
@@ -1,0 +1,14 @@
+---
+srcFiles:
+  - "!sites/*/files/**"
+  - "!xmlrpc.php"
+  - "!modules/php/*"
+projFiles:
+  - "README*"
+  - "bin/**"
+  - "hooks/**"
+  - "src/*.make"
+  - "vendor/**"
+dest:
+  docroot: "html"
+  devResources: ""

--- a/lib/drupal.js
+++ b/lib/drupal.js
@@ -58,6 +58,7 @@ module.exports = function(grunt) {
   module.drupalPath = function(type) {
     switch (module.majorVersion()) {
       case 8:
+      case 9:
         return path.join(grunt.config('config.buildPaths.html'), type);
       case 7:
       default:

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2807,6 +2807,238 @@
       "from": "lazystream@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz"
     },
+    "load-grunt-configs": {
+      "version": "1.0.0",
+      "from": "load-grunt-configs@latest",
+      "resolved": "https://registry.npmjs.org/load-grunt-configs/-/load-grunt-configs-1.0.0.tgz",
+      "dependencies": {
+        "cson-parser": {
+          "version": "1.3.5",
+          "from": "cson-parser@>=1.0.9 <2.0.0",
+          "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-1.3.5.tgz",
+          "dependencies": {
+            "coffee-script": {
+              "version": "1.12.7",
+              "from": "coffee-script@>=1.10.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz"
+            }
+          }
+        },
+        "inquirer": {
+          "version": "0.8.5",
+          "from": "inquirer@>=0.8.2 <0.9.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.5.tgz",
+          "dependencies": {
+            "ansi-regex": {
+              "version": "1.1.1",
+              "from": "ansi-regex@>=1.1.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "from": "chalk@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.2.1",
+                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "from": "escape-string-regexp@>=1.0.5 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                }
+              }
+            },
+            "cli-width": {
+              "version": "1.1.1",
+              "from": "cli-width@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.1.tgz"
+            },
+            "figures": {
+              "version": "1.7.0",
+              "from": "figures@>=1.3.5 <2.0.0",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+              "dependencies": {
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "from": "escape-string-regexp@>=1.0.5 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                },
+                "object-assign": {
+                  "version": "4.1.1",
+                  "from": "object-assign@>=4.1.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+                }
+              }
+            },
+            "readline2": {
+              "version": "0.1.1",
+              "from": "readline2@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+              "dependencies": {
+                "mute-stream": {
+                  "version": "0.0.4",
+                  "from": "mute-stream@0.0.4",
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
+                }
+              }
+            },
+            "rx": {
+              "version": "2.5.3",
+              "from": "rx@>=2.4.3 <3.0.0",
+              "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.3.tgz"
+            },
+            "through": {
+              "version": "2.3.8",
+              "from": "through@>=2.3.6 <3.0.0",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+            }
+          }
+        },
+        "js-yaml": {
+          "version": "3.10.0",
+          "from": "js-yaml@>=3.2.7 <4.0.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.9",
+              "from": "argparse@>=1.0.7 <2.0.0",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+              "dependencies": {
+                "sprintf-js": {
+                  "version": "1.0.3",
+                  "from": "sprintf-js@>=1.0.2 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                }
+              }
+            },
+            "esprima": {
+              "version": "4.0.0",
+              "from": "esprima@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz"
+            }
+          }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "from": "lodash@>=3.6.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "from": "rimraf@>=2.3.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "7.1.2",
+              "from": "glob@>=7.0.5 <8.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+              "dependencies": {
+                "fs.realpath": {
+                  "version": "1.0.0",
+                  "from": "fs.realpath@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+                },
+                "inflight": {
+                  "version": "1.0.6",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                },
+                "minimatch": {
+                  "version": "3.0.4",
+                  "from": "minimatch@>=3.0.4 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.8",
+                      "from": "brace-expansion@>=1.1.7 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "1.0.0",
+                          "from": "balanced-match@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.4.0",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.1",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "load-json-file": {
       "version": "1.1.0",
       "from": "load-json-file@>=1.0.0 <2.0.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "fs-extra": "~3.0.1",
     "grunt": "^1.0.1",
     "grunt-available-tasks": "~0.6.2",
+    "load-grunt-configs": "~1.0.0",
     "grunt-composer": "~0.4.4",
     "grunt-concurrent": "^2.1.0",
     "grunt-contrib-clean": "^1.0.0",

--- a/tasks/package.js
+++ b/tasks/package.js
@@ -113,8 +113,13 @@ module.exports = function(grunt) {
         }
       });
       tasks.push('composer:install');
-      grunt.config(['composer', 'drupal-scaffold'], {});
-      tasks.push('composer:drupal-scaffold');
+
+      // Add the drupal-scaffold task if it is defined in the `composer.json`.
+      var composer = JSON.parse(require('fs').readFileSync('./composer.json', 'utf8'));
+      if (typeof composer.scripts !== 'undefined' && 'drupal-scaffold' in composer.scripts) {
+        grunt.config(['composer', 'drupal-scaffold'], {});
+        tasks.push('composer:drupal-scaffold');
+      }
     }
 
     if (this.args[0] && this.args[0] === 'compress') {

--- a/test/test_assets/Gruntconfig.json
+++ b/test/test_assets/Gruntconfig.json
@@ -1,14 +1,11 @@
 {
   "srcPaths": {
+    "configDir": "config",
     "make": "src/project.make",
     "drupal": "src"
   },
   "siteUrls": {
     "default": "http://project.local"
-  },
-  "packages": {
-    "srcFiles": ["!sites/*/files/**", "!xmlrpc.php", "!modules/php/*"],
-    "projFiles": ["README*", "bin/**"]
   },
   "phpcs": true,
   "phpmd": true,

--- a/test/test_assets/config/packages.yml
+++ b/test/test_assets/config/packages.yml
@@ -1,0 +1,8 @@
+---
+srcFiles:
+  - "!sites/*/files/**"
+  - "!xmlrpc.php"
+  - "!modules/php/*"
+projFiles:
+  - "README*"
+  - "bin/**"

--- a/test/test_assets_d8/Gruntconfig.json
+++ b/test/test_assets_d8/Gruntconfig.json
@@ -1,18 +1,11 @@
 {
   "domain": "http://127.0.0.1:8080",
   "srcPaths": {
+    "configDir": "config",
     "drupal": "src"
   },
   "siteUrls": {
     "default": "http://project.local"
-  },
-  "packages": {
-    "srcFiles": ["!sites/*/files/**", "!xmlrpc.php", "!modules/php/*"],
-    "projFiles": ["README*", "bin/**", "hooks/**", "src/*.make", "vendor/**", "composer.*"],
-    "dest": {
-      "docroot": "html",
-      "devResources": ""
-    }
   },
   "phpcs": true,
   "phpmd": true,

--- a/test/test_assets_d8/config/packages.yml
+++ b/test/test_assets_d8/config/packages.yml
@@ -1,0 +1,15 @@
+---
+srcFiles:
+  - "!sites/*/files/**"
+  - "!xmlrpc.php"
+  - "!modules/php/*"
+projFiles:
+  - "README*"
+  - "bin/**"
+  - "hooks/**"
+  - "src/*.make"
+  - "vendor/**"
+  - "composer.*"
+dest:
+  docroot: "html"
+  devResources: ""


### PR DESCRIPTION
Instead of using one big _Gruntconfig.js_ file, this patch allows the configuration of basic options on this file and use separate files inside one directory for the configuration of the different tasks **grunt-drupal-tasks**.

To achieve this we use load-grunt-configs [0]. This module allows you to split your Grunt task configuration objects into separate files any way you choose. With it you also can configure targets for a single task in multiple files.

On the _example_ directory we migrate the configurations of the package task to use this new format, keeping the rest of the configuration on the _Gruntconfig.js_ file.

For using this feature, it only requires to add the key **config_dir** to the **srcPaths** object.

[0] https://www.npmjs.com/package/load-grunt-configs