### PR TITLE
 Allow using packages.dest.devResources with composer.json

### DIFF
--- a/tasks/package.js
+++ b/tasks/package.js
@@ -17,7 +17,8 @@ module.exports = function(grunt) {
     if ((pathBuild !== pathPackage) || pathVendor) {
       // Load `composer.json` as JSON, convert to object.
       var destPath = grunt.option('package-dest');
-      var composer = grunt.file.readJSON(destPath + '/composer.json');
+      var composerPath = path.resolve(destPath, grunt.config.get('config.packages.dest.devResources') || '');
+      var composer = grunt.file.readJSON(composerPath + '/composer.json');
       // Determine new installer-paths
       var pathInstall = pathPackage ? pathPackage + '/' : '';
       if (pathVendor) {
@@ -47,7 +48,7 @@ module.exports = function(grunt) {
       grunt.file.write(destComposer + '/composer.json', composerString);
       if (pathVendor) {
         // Remove the original file if we moved it.
-        grunt.file.delete(destPath + '/composer.json');
+        grunt.file.delete(composerPath + '/composer.json');
         // Change working directory for later `composer install`.
         grunt.config(['composer'], {
           options: {


### PR DESCRIPTION
When using a non empty **packages.dest.devResources** the task **packageRewriteComposer** fails, because it does not find the _composer.json_ file on _destPath_.

This variable is set to **grunt.config.get('config.buildPaths.packages') + '/' + packageName** on line 78 of **tasks/package.js**. And then the **packageRewriteComposer** search for composer.json on that location.

But the **copy:package** task will copy the composer.json project's file to **path.resolve(destPath, grunt.config.get('config.packages.dest.devResources') || '')**, breaking the task.

With this patch I rebuild de location of the composer.json file when running **packageRewriteComposer**.