### PR TITLE
Correct path of the config.serve.concurrent configuration

### DIFF
--- a/tasks/serve.js
+++ b/tasks/serve.js
@@ -55,7 +55,7 @@ module.exports = function(grunt) {
         grunt.loadNpmTasks('grunt-concurrent');
 
         // Allow overriding the tasks run concurrently to the Drupal server.
-        var serveTasks = grunt.config('serve.concurrent');
+        var serveTasks = grunt.config('config.serve.concurrent');
         if (!serveTasks) {
           serveTasks = ['watch-test'];
           if (grunt.task.exists('watch-theme')) {


### PR DESCRIPTION
The **config** prefix of the path **serve.concurrent** used on the **serve** task is missing.

Without it, there is no way of overriding the tasks that run concurrently when serving the site with _grunt_.

This commit correct the path to **config.serve.concurrent**, so it will be able to override it.